### PR TITLE
[SDAN - 11] - Notifications on followed topics

### DIFF
--- a/assets/components/NotificationList.jsx
+++ b/assets/components/NotificationList.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+
+class NotificationList extends React.Component {
+    constructor(props) {
+        super(props);
+        this.root = document.getElementById('header-notification');
+    }
+
+    render() {
+        return this.root ? ReactDOM.createPortal(
+            <span>
+                <i className='icon--alert icon--white' >
+                    {this.props.newItems && this.props.newItems.length}
+                </i>
+            </span>,
+            this.root
+        ) : null;
+    }
+}
+
+NotificationList.propTypes = {
+    newItems: PropTypes.array,
+};
+
+export default NotificationList;

--- a/assets/wire/actions.js
+++ b/assets/wire/actions.js
@@ -261,13 +261,14 @@ export function submitDownloadItems(items, format) {
 }
 
 export const SET_NEW_ITEMS = 'SET_NEW_ITEMS';
-export function setNewItems(newItems, data) {
-    return {type: SET_NEW_ITEMS, newItems, data};
+export function setNewItems(data) {
+    return {type: SET_NEW_ITEMS, data};
 }
 
-export const REFRESH_ITEMS = 'REFRESH_ITEMS';
-export function refreshItems() {
-    return {type: REFRESH_ITEMS};
+
+export const REMOVE_NEW_ITEMS = 'REMOVE_NEW_ITEMS';
+export function removeNewItems(data) {
+    return {type: REMOVE_NEW_ITEMS, data};
 }
 
 /**
@@ -280,10 +281,10 @@ export function pushNotification(push) {
         const state = getState();
         switch (push.event) {
         case 'update':
-            return search(state).then((data) => {
-                const newItems = data._items.filter((item) => !state.itemsById[item._id]);
-                return dispatch(setNewItems(newItems, data));
-            });
+            if (state.itemsById[push.extra.item._id]){
+                state.itemsById[push.extra.item._id] = push.extra.item;
+            }
+            return dispatch(setNewItems(push.extra));
         }
     };
 }

--- a/assets/wire/components/SearchSidebar.jsx
+++ b/assets/wire/components/SearchSidebar.jsx
@@ -30,25 +30,6 @@ class SearchSidebar extends React.Component {
     }
 
     render() {
-        const tabContents = this.tabs.map((tab) => {
-            const Tab = tab.content;
-            const className = classNames('tab-pane', 'fade', {'show active': this.state.active === tab});
-            return (
-                <div className='tab-content' key={tab.label}>
-                    <div className={className} role='tabpanel'>
-                        <Tab
-                            services={this.props.services}
-                            activeService={this.props.activeService}
-                            selectService={this.selectService}
-                            activeFilter={this.props.activeFilter}
-                            selectFilter={this.selectFilter}
-                            aggregations={this.props.aggregations}
-                        />
-                    </div>
-                </div>
-            );
-        });
-
         return (
             <div className='wire-column__nav__items'>
                 <ul className='nav justify-content-center mb-3' id='pills-tab' role='tablist'>
@@ -64,7 +45,38 @@ class SearchSidebar extends React.Component {
                         </li>
                     ))}
                 </ul>
-                {tabContents}
+                <div className='tab-content' key={gettext('Navigation')}>
+                    <div className={classNames('tab-pane', 'fade', {'show active': this.state.active === this.tabs[0]})} role='tabpanel'>
+                        <NavigationTab
+                            services={this.props.services}
+                            activeService={this.props.activeService}
+                            selectService={this.selectService}
+                            activeFilter={this.props.activeFilter}
+                            selectFilter={this.selectFilter}
+                            aggregations={this.props.aggregations}
+                        />
+                        {this.props.topics.length && <span className='wire-column__nav__divider'></span>}
+                        <TopicsTab
+                            topics={this.props.topics}
+                            setQuery={this.props.setQuery}
+                            activeQuery={this.props.activeQuery}
+                            newItemsByTopic={this.props.newItemsByTopic}
+                            removeNewItems={this.props.removeNewItems}
+                        />
+                    </div>
+                </div>
+                <div className='tab-content' key={gettext('Filters')}>
+                    <div className={classNames('tab-pane', 'fade', {'show active': this.state.active === this.tabs[1]})} role='tabpanel'>
+                        <FiltersTab
+                            services={this.props.services}
+                            activeService={this.props.activeService}
+                            selectService={this.selectService}
+                            activeFilter={this.props.activeFilter}
+                            selectFilter={this.selectFilter}
+                            aggregations={this.props.aggregations}
+                        />
+                    </div>
+                </div>
             </div>
         );
     }
@@ -129,7 +141,7 @@ function FiltersTab({aggregations, activeFilter, selectFilter}) {
         }
 
         return (
-            <div key={group.field} className="wire-column__nav__group">
+            <div key={group.field} className='wire-column__nav__group'>
                 <h5>{group.label}</h5>
                 {buckets}
             </div>
@@ -143,10 +155,39 @@ FiltersTab.propTypes = {
     selectFilter: PropTypes.func.isRequired,
 };
 
+function TopicsTab({topics, setQuery, activeQuery, newItemsByTopic, removeNewItems}) {
+    const query = (e, topic) => {
+        e.preventDefault();
+        removeNewItems(topic._id);
+        setQuery(topic.query);
+    };
+    return topics.map((topic) => (
+        <a href='#' key={topic._id}
+            className={classNames('wire-button', {
+                active: topic.query === activeQuery,
+            })}
+            onClick={(e) => query(e, topic)}>
+            {topic.label}
+            {newItemsByTopic && newItemsByTopic[topic._id] && <span className='wire-button__notif'>
+                {newItemsByTopic[topic._id].length}
+            </span>}
+        </a>
+    ));
+}
+
+TopicsTab.propTypes = {
+    topics: PropTypes.array.isRequired,
+    setQuery: PropTypes.func.isRequired,
+    activeQuery: PropTypes.string,
+    removeNewItems: PropTypes.func,
+    newItemsByTopic: PropTypes.object,
+};
+
 SearchSidebar.propTypes = {
     activeQuery: PropTypes.string,
     topics: PropTypes.array.isRequired,
     setQuery: PropTypes.func.isRequired,
+    removeNewItems: PropTypes.func,
     bookmarkedItems: PropTypes.array.isRequired,
     itemsById: PropTypes.object.isRequired,
     services: PropTypes.array.isRequired,
@@ -154,6 +195,7 @@ SearchSidebar.propTypes = {
     dispatch: PropTypes.func.isRequired,
     activeService: PropTypes.object,
     activeFilter: PropTypes.object,
+    newItemsByTopic: PropTypes.object,
 };
 
 const mapStateToProps = (state) => ({
@@ -163,6 +205,7 @@ const mapStateToProps = (state) => ({
     activeService: state.wire.activeService,
     activeFilter: state.wire.activeFilter,
     aggregations: state.aggregations,
+    newItemsByTopic: state.newItemsByTopic,
 });
 
 export default connect(mapStateToProps)(SearchSidebar);

--- a/assets/wire/components/WireApp.jsx
+++ b/assets/wire/components/WireApp.jsx
@@ -14,7 +14,7 @@ import {
     bookmarkItems,
     removeBookmarks,
     downloadItems,
-    refreshItems,
+    removeNewItems,
     openItem,
 } from 'wire/actions';
 
@@ -29,6 +29,7 @@ import FollowTopicModal from 'components/FollowTopicModal';
 import ShareItemModal from './ShareItemModal';
 import DownloadItemsModal from './DownloadItemsModal';
 import ItemDetails from './ItemDetails';
+import NotificationList from 'components/NotificationList';
 
 const modals = {
     followTopic: FollowTopicModal,
@@ -70,7 +71,8 @@ class WireApp extends React.Component {
                 item={this.props.itemToOpen}
                 actions={this.props.actions.filter(previewActionFilter)}
                 onClose={() => this.props.actions.filter(a => a.id == 'open')[0].action(null)}
-            />, modal] : [
+            />, modal,
+            <NotificationList key="notificationList" newItems={this.props.newItems}/>] : [
                 <section key="contentHeader" className='content-header'>
                     {this.props.selectedItems && this.props.selectedItems.length > 0 &&
                         <SelectedItemsBar
@@ -142,6 +144,7 @@ class WireApp extends React.Component {
                                 topics={this.props.topics}
                                 setQuery={this.props.setQuery}
                                 activeQuery={this.props.activeQuery}
+                                removeNewItems={this.props.removeNewItems}
                             />
                             }
 
@@ -165,16 +168,6 @@ class WireApp extends React.Component {
                                     />
                                 }
 
-                                {!!this.props.newItemsCount && (
-                                    <nav className="navbar">
-                                        <div className="form-inline">
-                                            <button className="btn" onClick={this.props.refreshItems}>
-                                                {gettext('Refresh')} <span className="badge badge-secondary">{this.props.newItemsCount}</span>
-                                            </button>
-                                        </div>
-                                    </nav>
-                                )}
-
                                 <ItemsList actions={this.props.actions.filter(previewActionFilter)}/>
                             </div>
                         )}
@@ -190,6 +183,7 @@ class WireApp extends React.Component {
                         </div>
                     </div>
                     {modal}
+                    <NotificationList newItems={this.props.newItems}/>
                 </section>])
         );
     }
@@ -216,8 +210,8 @@ WireApp.propTypes = {
     selectAll: PropTypes.func,
     selectNone: PropTypes.func,
     bookmarks: PropTypes.bool,
-    newItemsCount: PropTypes.number,
-    refreshItems: PropTypes.func,
+    newItems: PropTypes.array,
+    removeNewItems: PropTypes.func,
 };
 
 const mapStateToProps = (state) => ({
@@ -232,7 +226,7 @@ const mapStateToProps = (state) => ({
     topics: state.topics,
     selectedItems: state.selectedItems,
     bookmarks: state.bookmarks,
-    newItemsCount: state.newItemsCount,
+    newItems: state.newItems,
 });
 
 const mapDispatchToProps = (dispatch) => ({
@@ -244,7 +238,7 @@ const mapDispatchToProps = (dispatch) => ({
     },
     selectAll: () => dispatch(selectAll()),
     selectNone: () => dispatch(selectNone()),
-    refreshItems: () => dispatch(refreshItems()),
+    removeNewItems: (topicId) => dispatch(removeNewItems(topicId)),
     actions: [
         {
             id: 'open',

--- a/assets/wire/tests/actions.spec.js
+++ b/assets/wire/tests/actions.spec.js
@@ -70,15 +70,11 @@ describe('wire actions', () => {
     });
 
     it('can populate new items on update notification', () => {
-        expect(store.getState().newItemsCount).toBe(0);
-        return store.dispatch(actions.pushNotification({event: 'update'}))
-            .then(() => {
-                expect(fetchMock.called('/search?')).toBeTruthy();
-                expect(store.getState().newItemsCount).toBe(1);
-                store.dispatch(actions.refreshItems());
-                expect(store.getState().newItemsCount).toBe(0);
-                expect(store.getState().items.length).toBe(1);
-            });
+        expect(store.getState().newItems.length).toBe(0);
+        store.dispatch(actions.pushNotification({
+            event: 'update', extra: {topics: [1], item:{'_id': 'a'}}}));
+        expect(store.getState().newItems.length).toBe(1);
+        expect(store.getState().newItemsByTopic[1].length).toBe(1);
     });
 
     it('can open item', () => {

--- a/newsroom/templates/layout.html
+++ b/newsroom/templates/layout.html
@@ -37,6 +37,7 @@
         <div class="form-inline my-lg-0 ml-auto p-2">
             <a class="nav-link" href="{{ url_for('users.settings') }}">{{ gettext('Settings') }}</a>
             <a class="nav-link" href="{{ url_for('auth.logout') }}">{{ gettext('Logout') }}</a>
+            <div class="nav-link" id="header-notification"></div>
             <a href="{{ url_for('users.user_profile') }}"><span class="badge badge-success">{{ session['name'] }}</span></a>
         </div>
         {% else %}

--- a/newsroom/topics/topics.py
+++ b/newsroom/topics/topics.py
@@ -21,3 +21,7 @@ class TopicsService(newsroom.Service):
 
 def get_user_topics(user_id):
     return list(superdesk.get_resource_service('topics').get(req=None, lookup={'user': user_id}))
+
+
+def get_notification_topics():
+    return list(superdesk.get_resource_service('topics').get(req=None, lookup={'notifications': True}))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+git://github.com/superdesk/superdesk-core@6734b16#egg=superdesk-core
+git+git://github.com/superdesk/superdesk-core@8cc5441#egg=superdesk-core
 flask-babel==0.11.2
 flask-webpack==0.1.0
 Flask-WTF==0.14.2


### PR DESCRIPTION
- Added topics list to the end of services in Navigation tab
- Removed the refresh action from search results bar
- Performing a `count` search using filters aggregation for finding matching topics on new items
- Client side every topic will display how many new items it has
- Top menu notification will only display total number of new items across topics for now