### PR TITLE
[SDAN-172] - Initial home page implementation

### DIFF
--- a/assets/cards/actions.js
+++ b/assets/cards/actions.js
@@ -1,0 +1,133 @@
+import { gettext, notify, errorHandler } from 'utils';
+import server from 'server';
+
+
+export const SELECT_CARD = 'SELECT_CARD';
+export function selectCard(id) {
+    return {type: SELECT_CARD, id};
+}
+
+export const EDIT_CARD = 'EDIT_CARD';
+export function editCard(event) {
+    return {type: EDIT_CARD, event};
+}
+
+export const NEW_CARD = 'NEW_CARD';
+export function newCard() {
+    return {type: NEW_CARD};
+}
+
+export const CANCEL_EDIT = 'CANCEL_EDIT';
+export function cancelEdit(event) {
+    return {type: CANCEL_EDIT, event};
+}
+
+export const SET_QUERY = 'SET_QUERY';
+export function setQuery(query) {
+    return {type: SET_QUERY, query};
+}
+
+export const QUERY_CARDS = 'QUERY_CARDS';
+export function queryCards() {
+    return {type: QUERY_CARDS};
+}
+
+export const GET_CARDS = 'GET_CARDS';
+export function getCards(data) {
+    return {type: GET_CARDS, data};
+}
+
+export const GET_PRODUCTS = 'GET_PRODUCTS';
+export function getProducts(data) {
+    return {type: GET_PRODUCTS, data};
+}
+
+export const SET_ERROR = 'SET_ERROR';
+export function setError(errors) {
+    return {type: SET_ERROR, errors};
+}
+
+
+/**
+ * Fetches cards
+ *
+ */
+export function fetchCards() {
+    return function (dispatch, getState) {
+        dispatch(queryCards());
+        const query = getState().query || '';
+
+        return server.get(`/cards/search?q=${query}`)
+            .then((data) => dispatch(getCards(data)))
+            .catch((error) => errorHandler(error, dispatch, setError));
+    };
+}
+
+
+/**
+ * Creates new cards
+ *
+ */
+export function postCard() {
+    return function (dispatch, getState) {
+
+        const card = getState().cardToEdit;
+        const url = `/cards/${card._id ? card._id : 'new'}`;
+
+        return server.post(url, card)
+            .then(function() {
+                if (card._id) {
+                    notify.success(gettext('Card updated successfully'));
+                } else {
+                    notify.success(gettext('Card created successfully'));
+                }
+                dispatch(fetchCards());
+            })
+            .catch((error) => errorHandler(error, dispatch, setError));
+
+    };
+}
+
+
+/**
+ * Deletes a card
+ *
+ */
+export function deleteCard() {
+    return function (dispatch, getState) {
+
+        const card = getState().cardToEdit;
+        const url = `/cards/${card._id}`;
+
+        return server.del(url)
+            .then(() => {
+                notify.success(gettext('Card deleted successfully'));
+                dispatch(fetchCards());
+            })
+            .catch((error) => errorHandler(error, dispatch, setError));
+    };
+}
+
+
+/**
+ * Fetches products
+ *
+ */
+export function fetchProducts() {
+    return function (dispatch) {
+        return server.get('/products/search')
+            .then((data) => {
+                dispatch(getProducts(data));
+            })
+            .catch((error) => errorHandler(error, dispatch, setError));
+    };
+}
+
+
+export function initViewData(data) {
+    return function (dispatch) {
+        dispatch(getCards(data.cards));
+        dispatch(getProducts(data.products));
+    };
+}
+

--- a/assets/cards/components/CardList.jsx
+++ b/assets/cards/components/CardList.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import CardListItem from './CardListItem';
+import { gettext } from 'utils';
+
+
+function CardList({cards, products, onClick, activeCardId}) {
+    const list = cards.map((card) =>
+        <CardListItem
+            key={card._id}
+            products={products}
+            card={card}
+            onClick={onClick}
+            isActive={activeCardId===card._id}/>
+    );
+
+    return (
+        <section className="content-main">
+            <div className="list-items-container">
+                <table className="table table-hover">
+                    <thead>
+                        <tr>
+                            <th>{ gettext('Label') }</th>
+                            <th>{ gettext('Type') }</th>
+                            <th>{ gettext('Product') }</th>
+                            <th>{ gettext('Created On') }</th>
+                        </tr>
+                    </thead>
+                    <tbody>{list}</tbody>
+                </table>
+            </div>
+        </section>
+    );
+}
+
+CardList.propTypes = {
+    cards: PropTypes.array.isRequired,
+    products: PropTypes.array.isRequired,
+    onClick: PropTypes.func.isRequired,
+    activeCardId: PropTypes.string
+};
+
+export default CardList;

--- a/assets/cards/components/CardListItem.jsx
+++ b/assets/cards/components/CardListItem.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { shortDate } from 'utils';
+
+
+function getProductName(products, id) {
+    return products.filter((product) => product._id == id)[0].name;
+}
+
+function CardListItem({card, products, isActive, onClick}) {
+    return (
+        <tr key={card._id}
+            className={isActive?'table--selected':null}
+            onClick={() => onClick(card._id)}>
+            <td className="name">{card.label}</td>
+            <td>{card.type}</td>
+            <td>{getProductName(products, card.config.product)}</td>
+            <td>{shortDate(card._created)}</td>
+        </tr>
+    );
+}
+
+CardListItem.propTypes = {
+    card: PropTypes.object,
+    products: PropTypes.array,
+    isActive: PropTypes.bool,
+    onClick: PropTypes.func,
+};
+
+export default CardListItem;

--- a/assets/cards/components/Cards.jsx
+++ b/assets/cards/components/Cards.jsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import EditCard from './EditCard';
+import CardList from './CardList';
+import SearchResultsInfo from 'wire/components/SearchResultsInfo';
+import {
+    cancelEdit,
+    deleteCard,
+    editCard,
+    newCard,
+    postCard,
+    selectCard,
+    setError,
+    fetchProducts,
+    saveProducts,
+} from '../actions';
+import {gettext} from 'utils';
+
+class Cards extends React.Component {
+    constructor(props, context) {
+        super(props, context);
+
+        this.isFormValid = this.isFormValid.bind(this);
+        this.save = this.save.bind(this);
+        this.deleteCard = this.deleteCard.bind(this);
+    }
+
+    isFormValid() {
+        let valid = true;
+        let errors = {};
+
+        if (!this.props.cardToEdit.label) {
+            errors.name = ['Please provide card label'];
+            valid = false;
+        }
+
+        this.props.dispatch(setError(errors));
+        return valid;
+    }
+
+    save(event) {
+        event.preventDefault();
+
+        if (!this.isFormValid()) {
+            return;
+        }
+
+        this.props.saveCard();
+    }
+
+    deleteCard(event) {
+        event.preventDefault();
+
+        if (confirm(gettext('Would you like to delete card: {{label}}', {label: this.props.cardToEdit.label}))) {
+            this.props.deleteCard();
+        }
+    }
+
+    render() {
+        const progressStyle = {width: '25%'};
+
+        return (
+            <div className="flex-row">
+                {(this.props.isLoading ?
+                    <div className="col d">
+                        <div className="progress">
+                            <div className="progress-bar" style={progressStyle} />
+                        </div>
+                    </div>
+                    :
+                    <div className="flex-col">
+                        {this.props.activeQuery &&
+                        <SearchResultsInfo
+                            totalItems={this.props.totalCards}
+                            query={this.props.activeQuery} />
+                        }
+                        <CardList
+                            cards={this.props.cards}
+                            products={this.props.products}
+                            onClick={this.props.selectCard}
+                            activeCardId={this.props.activeCardId} />
+                    </div>
+                )}
+                {this.props.cardToEdit &&
+                    <EditCard
+                        card={this.props.cardToEdit}
+                        onChange={this.props.editCard}
+                        errors={this.props.errors}
+                        onSave={this.save}
+                        onClose={this.props.cancelEdit}
+                        onDelete={this.deleteCard}
+                        products={this.props.products}
+                        saveProducts={this.props.saveProducts}
+                        fetchProducts={this.props.fetchProducts}
+                    />
+                }
+            </div>
+        );
+    }
+}
+
+Cards.propTypes = {
+    cards: PropTypes.arrayOf(PropTypes.object),
+    cardToEdit: PropTypes.object,
+    activeCardId: PropTypes.string,
+    selectCard: PropTypes.func,
+    editCard: PropTypes.func,
+    saveCard: PropTypes.func,
+    deleteCard: PropTypes.func,
+    newCard: PropTypes.func,
+    cancelEdit: PropTypes.func,
+    isLoading: PropTypes.bool,
+    activeQuery: PropTypes.string,
+    totalCards: PropTypes.number,
+    errors: PropTypes.object,
+    dispatch: PropTypes.func,
+    products: PropTypes.arrayOf(PropTypes.object),
+    saveProducts: PropTypes.func.isRequired,
+    fetchProducts: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = (state) => ({
+    cards: state.cards.map((id) => state.cardsById[id]),
+    cardToEdit: state.cardToEdit,
+    activeCardId: state.activeCardId,
+    isLoading: state.isLoading,
+    activeQuery: state.activeQuery,
+    totalCards: state.totalCards,
+    errors: state.errors,
+    products: state.products,
+});
+
+const mapDispatchToProps = (dispatch) => ({
+    selectCard: (_id) => dispatch(selectCard(_id)),
+    editCard: (event) => dispatch(editCard(event)),
+    saveCard: (type) => dispatch(postCard(type)),
+    deleteCard: (type) => dispatch(deleteCard(type)),
+    newCard: () => dispatch(newCard()),
+    cancelEdit: (event) => dispatch(cancelEdit(event)),
+    saveProducts: (products) => dispatch(saveProducts(products)),
+    fetchProducts: () => dispatch(fetchProducts()),
+    dispatch: dispatch,
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Cards);

--- a/assets/cards/components/CardsApp.jsx
+++ b/assets/cards/components/CardsApp.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import {
+    newCard,
+    setQuery,
+    fetchCards,
+} from '../actions';
+import Cards from './Cards';
+import ListBar from 'components/ListBar';
+
+
+class CardsApp extends React.Component {
+    constructor(props, context) {
+        super(props, context);
+    }
+
+    render() {
+        return (
+            [<ListBar
+                key="CardBar"
+                onNewItem={this.props.newCard}
+                setQuery={this.props.setQuery}
+                fetch={this.props.fetchCards}
+                buttonName={'Card'}
+            />,
+            <Cards key="Cards"
+            />]
+        );
+    }
+}
+
+CardsApp.propTypes = {
+    newCard: PropTypes.func,
+    fetchCards: PropTypes.func,
+    setQuery: PropTypes.func,
+};
+
+const mapDispatchToProps = {
+    newCard,
+    fetchCards,
+    setQuery,
+};
+
+export default connect(null, mapDispatchToProps)(CardsApp);

--- a/assets/cards/components/EditCard.jsx
+++ b/assets/cards/components/EditCard.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import TextInput from 'components/TextInput';
+import SelectInput from 'components/SelectInput';
+
+import { gettext } from 'utils';
+
+const cardTypes = [
+    {value: '', text: ''},
+    {value: '6-text-only', text: gettext('6-text-only')},
+    {value: '4-picture-text', text: gettext('4-picture-text')},
+];
+
+
+
+class EditCard extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.getProducts = this.getProducts.bind(this);
+    }
+
+    getProducts() {
+        const productList = [{ value: '', text: '' }];
+        this.props.products.map((product) => {
+            productList.push({ value: product._id, text: product.name });
+        });
+        return productList;
+    }
+
+    render() {
+        return (
+            <div className='list-item__preview'>
+                <div className='list-item__preview-header'>
+                    <h3>{this.props.card.name}</h3>
+                    <button
+                        id='hide-sidebar'
+                        type='button'
+                        className='icon-button'
+                        data-dismiss='modal'
+                        aria-label='Close'
+                        onClick={this.props.onClose}>
+                        <i className="icon--close-thin icon--gray" aria-hidden='true'></i>
+                    </button>
+                </div>
+
+                <form>
+                    <div className="list-item__preview-form">
+                        <TextInput
+                            name='label'
+                            label={gettext('Label')}
+                            value={this.props.card.label}
+                            onChange={this.props.onChange}
+                            error={this.props.errors ? this.props.errors.name : null}/>
+
+                        <SelectInput
+                            name='type'
+                            label={gettext('Type')}
+                            value={this.props.card.type}
+                            options={cardTypes}
+                            onChange={this.props.onChange}
+                            error={this.props.errors ? this.props.errors.type : null} />
+
+                        <SelectInput
+                            name='product'
+                            label={gettext('Product')}
+                            value={this.props.card.config.product}
+                            options={this.getProducts()}
+                            onChange={this.props.onChange}
+                            error={this.props.errors ? this.props.errors.product : null} />
+
+
+                    </div>
+                    <div className='list-item__preview-footer'>
+                        <input
+                            type='button'
+                            className='btn btn-outline-primary'
+                            value={gettext('Save')}
+                            onClick={this.props.onSave}/>
+                        <input
+                            type='button'
+                            className='btn btn-outline-secondary'
+                            value={gettext('Delete')}
+                            onClick={this.props.onDelete}/>
+                    </div>
+                </form>
+            </div>
+        );
+    }
+}
+
+EditCard.propTypes = {
+    card: PropTypes.object.isRequired,
+    onChange: PropTypes.func,
+    errors: PropTypes.object,
+    products: PropTypes.arrayOf(PropTypes.object),
+    onSave: PropTypes.func.isRequired,
+    onClose: PropTypes.func.isRequired,
+    onDelete: PropTypes.func.isRequired,
+    saveProducts: PropTypes.func.isRequired,
+    fetchProducts: PropTypes.func.isRequired,
+};
+
+export default EditCard;

--- a/assets/cards/components/EditCard.jsx
+++ b/assets/cards/components/EditCard.jsx
@@ -9,6 +9,9 @@ const cardTypes = [
     {value: '', text: ''},
     {value: '6-text-only', text: gettext('6-text-only')},
     {value: '4-picture-text', text: gettext('4-picture-text')},
+    {value: '4-media-gallery', text: gettext('4-media-gallery')},
+    {value: '1x1-top-news', text: gettext('1x1-top-news')},
+    {value: '2x2-top-news', text: gettext('2x2-top-news')},
 ];
 
 

--- a/assets/cards/index.js
+++ b/assets/cards/index.js
@@ -1,0 +1,15 @@
+import { createStore, render } from 'utils';
+import cardReducer from './reducers';
+import CardsApp from './components/CardsApp';
+import { initViewData } from './actions';
+
+
+const store = createStore(cardReducer);
+
+
+if (window.viewData) {
+    store.dispatch(initViewData(window.viewData));
+}
+
+
+render(store, CardsApp, document.getElementById('settings-app'));

--- a/assets/cards/reducers.js
+++ b/assets/cards/reducers.js
@@ -25,6 +25,9 @@ const initialState = {
 const cardSizes = {
     '6-text-only': 6,
     '4-picture-text': 4,
+    '4-media-gallery': 4,
+    '1x1-top-news': 2,
+    '2x2-top-news': 4,
 };
 
 export default function cardReducer(state = initialState, action) {

--- a/assets/cards/reducers.js
+++ b/assets/cards/reducers.js
@@ -1,0 +1,108 @@
+
+import {
+    GET_CARDS,
+    SELECT_CARD,
+    EDIT_CARD,
+    QUERY_CARDS,
+    SET_QUERY,
+    CANCEL_EDIT,
+    NEW_CARD,
+    SET_ERROR,
+    GET_PRODUCTS,
+} from './actions';
+
+const initialState = {
+    query: null,
+    cards: [],
+    cardsById: {},
+    activeCardId: null,
+    isLoading: false,
+    totalCards: null,
+    activeQuery: null,
+    products: [],
+};
+
+const cardSizes = {
+    '6-text-only': 6,
+    '4-picture-text': 4,
+};
+
+export default function cardReducer(state = initialState, action) {
+    switch (action.type) {
+
+    case SELECT_CARD: {
+        const defaultCard = {
+            label: '',
+            type: '',
+            config: {},
+        };
+
+        return {
+            ...state,
+            activeCardId: action.id || null,
+            cardToEdit: action.id ? Object.assign(defaultCard, state.cardsById[action.id]) : null,
+            errors: null,
+        };
+    }
+
+    case EDIT_CARD: {
+        const target = action.event.target;
+        const field = target.name;
+        let card = state.cardToEdit;
+
+        if (field === 'product') {
+            card['config']['product'] = target.value;
+        } else {
+            card[field] = target.value;
+        }
+
+        card['config']['size'] = cardSizes[state.cardToEdit.type];
+
+        return {...state, cardToEdit: card, errors: null};
+    }
+
+    case NEW_CARD: {
+        const cardToEdit = {
+            label: '',
+            type: '',
+            config: {},
+        };
+
+        return {...state, cardToEdit, errors: null};
+    }
+
+    case CANCEL_EDIT: {
+        return {...state, cardToEdit: null, errors: null};
+    }
+
+    case SET_QUERY:
+        return {...state, query: action.query};
+
+    case SET_ERROR:
+        return {...state, errors: action.errors};
+
+    case QUERY_CARDS:
+        return {...state,
+            isLoading: true,
+            totalCards: null,
+            cardToEdit: null,
+            activeQuery: state.query};
+
+    case GET_CARDS: {
+        const cardsById = Object.assign({}, state.cardsById);
+        const cards = action.data.map((card) => {
+            cardsById[card._id] = card;
+            return card._id;
+        });
+
+        return {...state, cards, cardsById, isLoading: false, totalCards: cards.length};
+    }
+
+    case GET_PRODUCTS: {
+        return {...state, products: action.data};
+    }
+
+    default:
+        return state;
+    }
+}

--- a/assets/home/actions.js
+++ b/assets/home/actions.js
@@ -1,0 +1,4 @@
+export const INIT_DATA = 'INIT_DATA';
+export function initData(data) {
+    return {type: INIT_DATA, data};
+}

--- a/assets/home/components/HomeApp.jsx
+++ b/assets/home/components/HomeApp.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import TextOnlyCard from './TextOnlyCard';
+import PictureTextCard from './PictureTextCard';
+
+const panels = {
+    '6-text-only': TextOnlyCard,
+    '4-picture-text': PictureTextCard,
+};
+
+class HomeApp extends React.Component {
+    constructor(props, context) {
+        super(props, context);
+        this.getPanels = this.getPanels.bind(this);
+    }
+
+    getPanels(card) {
+        const items = this.props.itemsByCard[card.label];
+        const Panel = panels[card.type];
+        return <Panel key={card.label} items={items} title={card.label}/>;
+    }
+
+    render() {
+        return (
+            <section className="content-main d-block py-4 px-2 p-md-3 p-lg-4">
+                <div className="container-fluid">
+                    {this.props.cards.map((card) => this.getPanels(card))}
+                </div>
+            </section>
+        );
+    }
+}
+
+HomeApp.propTypes = {
+    cards: PropTypes.arrayOf(PropTypes.object),
+    itemsByCard: PropTypes.object,
+};
+
+const mapStateToProps = (state) => ({
+    cards: state.cards,
+    itemsByCard: state.itemsByCard,
+});
+
+
+export default connect(mapStateToProps, null)(HomeApp);

--- a/assets/home/components/HomeApp.jsx
+++ b/assets/home/components/HomeApp.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import TextOnlyCard from './TextOnlyCard';
 import PictureTextCard from './PictureTextCard';
+import { gettext } from 'utils';
 
 const panels = {
     '6-text-only': TextOnlyCard,
@@ -25,7 +26,12 @@ class HomeApp extends React.Component {
         return (
             <section className="content-main d-block py-4 px-2 p-md-3 p-lg-4">
                 <div className="container-fluid">
-                    {this.props.cards.map((card) => this.getPanels(card))}
+                    {this.props.cards.length > 0 && this.props.cards.map((card) => this.getPanels(card))}
+                    {this.props.cards.length === 0 &&
+                        <div className="alert alert-warning" role="alert">
+                            <strong>{gettext('Warning')}!</strong> {gettext('There\'s no card defined for home page!')}
+                        </div>
+                    }
                 </div>
             </section>
         );

--- a/assets/home/components/HomeApp.jsx
+++ b/assets/home/components/HomeApp.jsx
@@ -3,11 +3,17 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import TextOnlyCard from './TextOnlyCard';
 import PictureTextCard from './PictureTextCard';
+import MediaGalleryCard from './MediaGalleryCard';
+import TopNewsOneByOneCard from './TopNewsOneByOneCard';
+import TopNewsTwoByTwoCard from './TopNewsTwoByTwoCard';
 import { gettext } from 'utils';
 
 const panels = {
     '6-text-only': TextOnlyCard,
     '4-picture-text': PictureTextCard,
+    '4-media-gallery': MediaGalleryCard,
+    '1x1-top-news': TopNewsOneByOneCard,
+    '2x2-top-news': TopNewsTwoByTwoCard,
 };
 
 class HomeApp extends React.Component {

--- a/assets/home/components/MediaGalleryCard.jsx
+++ b/assets/home/components/MediaGalleryCard.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { gettext, shortDate } from 'utils';
+import { getPicture, getPreviewRendition, getCaption } from 'wire/utils';
+
+const getMediaPanel = (item, picture) => {
+    
+    const rendition = getPreviewRendition(picture);
+    const imageUrl = rendition && rendition.href;
+    const caption = rendition && getCaption(picture);
+
+    return (<div key={item._id} className='col-sm-6 col-lg-3 d-flex mb-4'>
+        <div className='card card--home card--gallery'>
+            <img className='card-img-top' src={imageUrl} alt={caption} />
+            <div className='card-body'>
+                <div className='wire-articles__item__meta'>                                
+                    <div className='wire-articles__item__meta-info'>                                    
+                        <span>{gettext('Source: {{ source }}', {source: item.source})} {'//'} {shortDate(item.versioncreated)}</span>
+                    </div>
+                </div>                        
+                <h4 className='card-title'>{item.headline}</h4>
+            </div>
+        </div>
+    </div>);
+};
+
+function MediaGalleryCard({items, title}) {
+    return (
+        <div className='row'>
+            <div className='col-6 col-sm-8'>
+                <h3 className='home-section-heading'>{title}</h3>
+            </div>
+            <div className='col-6 col-sm-4 d-flex align-items-start justify-content-end'>
+                <button type='button' className='btn btn-outline-primary btn-sm mb-3'>{gettext('More news')}</button>
+            </div>
+            {items.map((item) => getMediaPanel(item, getPicture(item)))}
+        </div>
+    );
+}
+
+MediaGalleryCard.propTypes = {
+    items: PropTypes.array,
+    title: PropTypes.string,
+};
+
+export default MediaGalleryCard;

--- a/assets/home/components/PictureTextCard.jsx
+++ b/assets/home/components/PictureTextCard.jsx
@@ -31,7 +31,7 @@ const getPictureTextPanel = (item, picture) => {
                         </span>
                     </div>
                     <div className="wire-articles__item__meta-info">
-                        <span><span className="bold">{wordCount(item)}</span> words</span>
+                        <span><span className="bold">{wordCount(item)}</span> {gettext('words')}</span>
                     </div>
                 </div>
             </div>

--- a/assets/home/components/PictureTextCard.jsx
+++ b/assets/home/components/PictureTextCard.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { gettext, shortDate, wordCount } from 'utils';
+import { getPicture, getPreviewRendition, getCaption } from 'wire/utils';
+
+const getPictureTextPanel = (item, picture) => {
+    const rendition = getPreviewRendition(picture);
+    const imageUrl = rendition && rendition.href;
+    const caption = rendition && getCaption(picture);
+
+    return (<div key={item._id} className="col-sm-6 col-lg-3 d-flex mb-4">
+        <div className="card card--home">
+            <img className="card-img-top" src={imageUrl} alt={caption} />
+            <div className="card-body">
+                <h4 className="card-title">{item.headline}</h4>
+                <div className="wire-articles__item__meta">
+                    <div className="wire-articles__item__meta-info">
+                        <span className="bold">{item.slugline}</span>
+                        <span>{gettext('Source: {{ source }}', {source: item.source})} {'//'} {shortDate(item.versioncreated)}</span>
+                    </div>
+                </div>
+            </div>
+            <div className="card-footer">
+                <div className="wire-articles__item__meta">
+                    <div className="wire-articles__item__icons">
+                        <span className="wire-articles__item__icon">
+                            <i className="icon--text icon--gray-light"></i>
+                        </span>
+                        <span className="wire-articles__item__icon">
+                            <i className="icon--photo icon--gray-light"></i>
+                        </span>
+                    </div>
+                    <div className="wire-articles__item__meta-info">
+                        <span><span className="bold">{wordCount(item)}</span> words</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>);
+};
+
+function PictureTextCard({items, title}) {
+    return (
+        <div className='row'>
+            <div className='col-6 col-sm-8'>
+                <h3 className='home-section-heading'>{title}</h3>
+            </div>
+            <div className='col-6 col-sm-4 d-flex align-items-start justify-content-end'>
+                <button type='button' className='btn btn-outline-primary btn-sm mb-3'>{gettext('More news')}</button>
+            </div>
+            {items.map((item) => getPictureTextPanel(item, getPicture(item)))}
+        </div>
+    );
+}
+
+PictureTextCard.propTypes = {
+    items: PropTypes.array,
+    title: PropTypes.string,
+};
+
+export default PictureTextCard;

--- a/assets/home/components/TextOnlyCard.jsx
+++ b/assets/home/components/TextOnlyCard.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { gettext, shortDate, fullDate, wordCount } from 'utils';
+
+const getTextOnlyPanel = item => (
+    <div key={item._id} className='col-sm-6 col-md-4 col-lg-2 d-flex mb-4'>
+        <div className='card card--home'>
+            <div className='card-body'>
+                <h5 className='card-title'>{item.headline}</h5>
+                <div className='wire-articles__item__meta'>
+                    <div className='wire-articles__item__meta-info'>
+                        <span className='bold'>{item.slugline}</span>
+                        <span>{gettext('Source: {{ source }}', {source: item.source})}
+                            {' // '}<span className='bold'>{wordCount(item)}</span> {gettext('words')}
+                            {' // '}<time dateTime={fullDate(item.versioncreated)}>{shortDate(item.versioncreated)}</time>
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+);
+
+function TextOnlyCard({items, title}) {
+    return (
+        <div className='row'>
+            <div className='col-6 col-sm-8'>
+                <h3 className='home-section-heading'>{title}</h3>
+            </div>
+            <div className='col-6 col-sm-4 d-flex align-items-start justify-content-end'>
+                <button type='button' className='btn btn-outline-primary btn-sm mb-3'>{gettext('More news')}</button>
+            </div>
+            {items.map((item) => getTextOnlyPanel(item))}
+        </div>
+    );
+}
+
+TextOnlyCard.propTypes = {
+    items: PropTypes.array,
+    title: PropTypes.string,
+};
+
+export default TextOnlyCard;

--- a/assets/home/components/TopNewsOneByOneCard.jsx
+++ b/assets/home/components/TopNewsOneByOneCard.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { gettext, shortDate, fullDate, wordCount } from 'utils';
+import { getPicture, getPreviewRendition, getCaption } from 'wire/utils';
+
+const getTopNewsPanel = (item, picture) => {
+    
+    const rendition = getPreviewRendition(picture);
+    const imageUrl = rendition && rendition.href;
+    const caption = rendition && getCaption(picture);
+
+    return (<div key={item._id} className='col-sm-12 col-md-6 d-flex mb-4'>
+        <div className='card card--home'>
+            <img className='card-img-top' src={imageUrl} alt={caption} />
+            <div className='card-body'>
+                <h4 className='card-title'>{item.headline}</h4>
+                <div className='wire-articles__item__meta'>
+                    <div className='wire-articles__item__icons'>
+                        <span className='wire-articles__item__icon'>
+                            <i className='icon--text icon--gray-light'></i>
+                        </span>
+                        <span className='wire-articles__item__icon'>
+                            <i className='icon--photo icon--gray-light'></i>
+                        </span>
+                        <span className='wire-articles__item__divider'>
+                        </span>
+                    </div>
+                    <div className='wire-articles__item__meta-info'>
+                        <span className='bold'>{item.slugline}</span>
+                        <span>{gettext('Source: {{ source }}', {source: item.source})}
+                            {' // '}<span className='bold'>{wordCount(item)}</span> {gettext('words')}
+                            {' // '}<time dateTime={fullDate(item.versioncreated)}>{shortDate(item.versioncreated)}</time>
+                        </span>
+                    </div>
+                </div>
+                <div className='wire-articles__item__text'>
+                    <p className='card-text small'>{item.description_text}</p>
+                </div>
+            </div>
+        </div>
+    </div>);
+};
+
+function TopNewsOneByOneCard({items, title}) {
+    return (
+        <div className='row'>
+            <div className='col-6 col-sm-8'>
+                <h3 className='home-section-heading'>{title}</h3>
+            </div>
+            <div className='col-6 col-sm-4 d-flex align-items-start justify-content-end'>
+                <button type='button' className='btn btn-outline-primary btn-sm mb-3'>{gettext('More news')}</button>
+            </div>
+            {items.map((item) => getTopNewsPanel(item, getPicture(item)))}
+        </div>
+    );
+}
+
+TopNewsOneByOneCard.propTypes = {
+    items: PropTypes.array,
+    title: PropTypes.string,
+};
+
+export default TopNewsOneByOneCard;

--- a/assets/home/components/TopNewsTwoByTwoCard.jsx
+++ b/assets/home/components/TopNewsTwoByTwoCard.jsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { gettext, shortDate, fullDate, wordCount } from 'utils';
+import { getPicture, getPreviewRendition, getCaption } from 'wire/utils';
+
+const getTopNewsLeftPanel = (item, picture) => {
+
+    const rendition = getPreviewRendition(picture);
+    const imageUrl = rendition && rendition.href;
+    const caption = rendition && getCaption(picture);
+
+    return (<div key={item._id} className='col-sm-6 col-md-9 d-flex mb-4'>
+        <div className='card card--home card--horizontal'>
+            <div className='card-image-left'>
+                <img src={imageUrl} alt={caption} />
+            </div>                        
+            <div className='card-body'>
+                <h2 className='card-title'>{item.headline}</h2>
+                <div className='wire-articles__item__meta'>
+                    <div className='wire-articles__item__icons'>
+                        <span className='wire-articles__item__icon'>
+                            <i className='icon--text icon--gray-light'></i>
+                        </span>
+                        <span className='wire-articles__item__icon'>
+                            <i className='icon--photo icon--gray-light'></i>
+                        </span>
+                        <span className='wire-articles__item__divider'>
+                        </span>
+                    </div>
+                    <div className='wire-articles__item__meta-info'>
+                        <span className='bold'>{item.slugline}</span>
+                        <span>{gettext('Source: {{ source }}', {source: item.source})}
+                            {' // '}<span className='bold'>{wordCount(item)}</span> {gettext('words')}
+                            {' // '}<time dateTime={fullDate(item.versioncreated)}>{shortDate(item.versioncreated)}</time>
+                        </span>
+                    </div>
+                </div>
+                <div className='wire-articles__item__text'>
+                    <p className='card-text'>{item.description_text}</p>
+                </div>
+            </div>                        
+        </div>
+    </div>
+    );
+};
+  
+const getTopNewsRightPanel = (item, picture) => {
+
+    const rendition = getPreviewRendition(picture);
+    const imageUrl = rendition && rendition.href;
+    const caption = rendition && getCaption(picture);
+
+    return (<div key={item._id} className='col-sm-6 col-md-3 d-flex mb-4'>
+        <div className='card card--home'>
+            <img className='card-img-top' src={imageUrl} alt={caption} />
+            <div className='card-body'>
+                <h4 className='card-title'>{item.headline}</h4>
+                <div className='wire-articles__item__meta'>
+                    <div className='wire-articles__item__meta-info'>
+                        <span className='bold'>{item.slugline}</span>
+                        <span>{gettext('Source: {{ source }}', {source: item.source})} {'//'} {shortDate(item.versioncreated)}</span>
+                    </div>
+                </div>
+            </div>
+            <div className='card-footer'>
+                <div className='wire-articles__item__meta'>
+                    <div className='wire-articles__item__icons'>
+                        <span className='wire-articles__item__icon'>
+                            <i className='icon--text icon--gray-light'></i>
+                        </span>
+                        <span className='wire-articles__item__icon'>
+                            <i className='icon--photo icon--gray-light'></i>
+                        </span>
+                    </div>
+                    <div className='wire-articles__item__meta-info'>
+                        <span><span className="bold">{wordCount(item)}</span> {gettext('words')}</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>);
+};
+
+const getTopNews = (items) => {
+    const topNews = [];
+    for(var i=0; i<items.length; i+=2) {
+        topNews.push(getTopNewsLeftPanel(items[i], getPicture(items[i])));
+        if (i+1 < length) {
+            topNews.push(getTopNewsRightPanel(items[i+1], getPicture(items[i+1])));
+        }
+    }
+    return topNews;
+};
+
+function TopNewsTwoByTwoCard({items, title}) {
+    return (
+        <div className='row'>
+            <div className='col-6 col-sm-8'>
+                <h3 className='home-section-heading'>{title}</h3>
+            </div>
+            <div className='col-6 col-sm-4 d-flex align-items-start justify-content-end'>
+                <button type='button' className='btn btn-outline-primary btn-sm mb-3'>{gettext('More news')}</button>
+            </div>
+            {getTopNews(items)}
+        </div>
+    );
+}
+
+TopNewsTwoByTwoCard.propTypes = {
+    items: PropTypes.array,
+    title: PropTypes.string,
+};
+
+export default TopNewsTwoByTwoCard;

--- a/assets/home/index.js
+++ b/assets/home/index.js
@@ -1,0 +1,18 @@
+import { createStore, render } from 'utils';
+import homeReducer from './reducers';
+import HomeApp from './components/HomeApp';
+import {initData} from './actions';
+
+
+const store = createStore(homeReducer);
+
+
+if (window.homeData) {
+    store.dispatch(initData(window.homeData));
+}
+
+render(
+    store,
+    HomeApp,
+    document.getElementById('home-app')
+);

--- a/assets/home/reducers.js
+++ b/assets/home/reducers.js
@@ -1,0 +1,24 @@
+
+import {
+    INIT_DATA,
+} from './actions';
+
+const initialState = {
+    cards: [],
+    itemsByCard: {},
+};
+
+export default function homeReducer(state = initialState, action) {
+    switch (action.type) {
+
+    case INIT_DATA:
+        return {
+            ...state,
+            cards: action.data.cards,
+            itemsByCard: action.data.itemsByCard
+        };
+
+    default:
+        return state;
+    }
+}

--- a/newsroom/cards/__init__.py
+++ b/newsroom/cards/__init__.py
@@ -1,0 +1,13 @@
+import superdesk
+from flask import Blueprint
+
+from .cards import CardsResource, CardsService
+
+blueprint = Blueprint('cards', __name__)
+
+
+def init_app(app):
+    superdesk.register_resource('cards', CardsResource, CardsService, _app=app)
+
+
+from . import views   # noqa

--- a/newsroom/cards/cards.py
+++ b/newsroom/cards/cards.py
@@ -1,0 +1,37 @@
+import newsroom
+
+
+class CardsResource(newsroom.Resource):
+    """
+    Cards schema
+    """
+    schema = {
+        'label': {
+            'type': 'string',
+            'unique': True,
+            'required': True
+        },
+        'type': {
+            'type': 'string',
+            'required': True,
+            'nullable': False,
+            'allowed': ['6-text-only', '4-picture-text'],
+        },
+        'config': {
+            'type': 'dict',
+        },
+        'order': {
+            'type': 'integer',
+            'nullable': True
+        }
+    }
+    datasource = {
+        'source': 'cards',
+        'default_sort': [('order', 1), ('label', 1)]
+    }
+    item_methods = ['GET', 'PATCH', 'DELETE']
+    resource_methods = ['GET', 'POST']
+
+
+class CardsService(newsroom.Service):
+    pass

--- a/newsroom/cards/cards.py
+++ b/newsroom/cards/cards.py
@@ -15,7 +15,13 @@ class CardsResource(newsroom.Resource):
             'type': 'string',
             'required': True,
             'nullable': False,
-            'allowed': ['6-text-only', '4-picture-text'],
+            'allowed': [
+                '6-text-only',
+                '4-picture-text',
+                '4-media-gallery',
+                '1x1-top-news',
+                '2x2-top-news',
+            ],
         },
         'config': {
             'type': 'dict',

--- a/newsroom/cards/views.py
+++ b/newsroom/cards/views.py
@@ -1,0 +1,84 @@
+import re
+import flask
+from bson import ObjectId
+from flask import jsonify
+from flask_babel import gettext
+from superdesk import get_resource_service
+
+from newsroom.auth.decorator import admin_only, login_required
+from newsroom.cards import blueprint
+from newsroom.utils import get_json_or_400, get_entity_or_404
+from newsroom.utils import query_resource
+
+
+@blueprint.route('/cards/settings', methods=['GET'])
+@admin_only
+def settings():
+    data = {
+        'products': list(query_resource('products', max_results=200)),
+        "cards": list(query_resource('cards', max_results=200)),
+    }
+    return flask.render_template('settings.html', setting_type="cards", data=data)
+
+
+@blueprint.route('/cards', methods=['GET'])
+@login_required
+def index():
+    cards = list(query_resource('cards', lookup=None, max_results=200))
+    return jsonify(cards), 200
+
+
+@blueprint.route('/cards/search', methods=['GET'])
+@admin_only
+def search():
+    lookup = None
+    if flask.request.args.get('q'):
+        regex = re.compile('.*{}.*'.format(flask.request.args.get('q')), re.IGNORECASE)
+        lookup = {'label': regex}
+    products = list(query_resource('cards', lookup=lookup, max_results=200))
+    return jsonify(products), 200
+
+
+@blueprint.route('/cards/new', methods=['POST'])
+@admin_only
+def create():
+    data = get_json_or_400()
+    if not data.get('label'):
+        return jsonify(gettext('Label not found')), 400
+
+    if not data.get('type'):
+        return jsonify(gettext('Type not found')), 400
+
+    ids = get_resource_service('cards').post([data])
+    return jsonify({'success': True, '_id': ids[0]}), 201
+
+
+@blueprint.route('/cards/<id>', methods=['POST'])
+@admin_only
+def edit(id):
+    card = get_entity_or_404(id, 'cards')
+
+    if not card.get('label'):
+        return jsonify(gettext('Label not found')), 400
+
+    if not card.get('type'):
+        return jsonify(gettext('Type not found')), 400
+
+    data = get_json_or_400()
+    updates = {
+        'label': data.get('label'),
+        'type': data.get('type'),
+        'config': data.get('config'),
+    }
+
+    get_resource_service('cards').patch(id=ObjectId(id), updates=updates)
+    return jsonify({'success': True}), 200
+
+
+@blueprint.route('/cards/<id>', methods=['DELETE'])
+@admin_only
+def delete(id):
+    """ Deletes the cards by given id """
+    get_entity_or_404(id, 'cards')
+    get_resource_service('cards').delete({'_id': ObjectId(id)})
+    return jsonify({'success': True}), 200

--- a/newsroom/default_settings.py
+++ b/newsroom/default_settings.py
@@ -39,6 +39,7 @@ BLUEPRINTS = [
     'newsroom.notifications',
     'newsroom.products',
     'newsroom.navigations',
+    'newsroom.cards',
 ]
 
 CORE_APPS = [
@@ -57,6 +58,7 @@ CORE_APPS = [
     'newsroom.notifications',
     'newsroom.products',
     'newsroom.navigations',
+    'newsroom.cards',
 ]
 
 SITE_NAME = 'AAP Newsroom'

--- a/newsroom/templates/home.html
+++ b/newsroom/templates/home.html
@@ -1,0 +1,19 @@
+{% extends "layout.html" %}
+
+{% block title %}{{ gettext('Home') }}{% endblock %}
+
+{% block breadcrumb %}
+<span class="breadcrumb-item active">{{ gettext('Home') }}</span>
+<span id="nav-breadcrumb" class="breadcrumb-item active"></span>
+{% endblock %}
+
+{% block content %}
+<div id="home-app" class="content"></div>
+{% endblock %}
+
+{% block script %}
+    <script>
+        homeData = {{ data | tojson | safe }};
+    </script>
+    {{ javascript_tag('home_js') | safe }}
+{% endblock %}

--- a/newsroom/templates/settings.html
+++ b/newsroom/templates/settings.html
@@ -32,6 +32,11 @@
                         {{ gettext('Products') }}</a>
                 </li>
                 <li>
+                    <a class="side-navigation__btn {{ "active" if setting_type == "cards" }}"
+                        href="{{ url_for('cards.settings') }}">
+                        {{ gettext('Home Page Cards') }}</a>
+                </li>
+                <li>
                     <a class="side-navigation__btn"
                         href='#'>{{ gettext('System Settings') }}</a>
                 </li>

--- a/newsroom/wire/__init__.py
+++ b/newsroom/wire/__init__.py
@@ -31,7 +31,7 @@ def init_app(app):
 
     superdesk.register_resource('wire_search', WireSearchResource, WireSearchService, _app=app)
 
-    app.sidenav('Wire', 'wire.index')
+    app.sidenav('Wire', 'wire.wire')
     app.sidenav('Bookmarks', 'wire.bookmarks')
 
     from .formatters import TextFormatter, NITFFormatter, NewsMLG2Formatter

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -45,11 +45,13 @@ def get_view_data():
 
 
 def get_home_data():
-    cards = [
-        {'label': 'Something', 'type': '6-text-only', 'config': {'product': '5a23c1131d41c82b8dd4267d', 'size': 6}},
-        {'label': 'Other Stories', 'type': '4-picture-text',
-         'config': {'product': '5a23c1131d41c82b8dd4267d', 'size': 4}},
-    ]
+    # cards = [
+    #     {'label': 'Something', 'type': '6-text-only', 'config': {'product': '5a23c1131d41c82b8dd4267d', 'size': 6}},
+    #     {'label': 'Other Stories', 'type': '4-picture-text',
+    #      'config': {'product': '5a23c1131d41c82b8dd4267d', 'size': 4}},
+    # ]
+
+    cards = list(superdesk.get_resource_service('cards').get(None, None))
 
     itemsByCard = {}
     for card in cards:
@@ -77,6 +79,12 @@ def get_previous_versions(item):
 def index():
     # return flask.render_template('wire_index.html', data=get_view_data())
     return flask.render_template('home.html', data=get_home_data())
+
+
+@blueprint.route('/wire')
+@login_required
+def wire():
+    return flask.render_template('wire_index.html', data=get_view_data())
 
 
 @blueprint.route('/bookmarks')

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -9,6 +9,7 @@ from eve.render import send_response
 from eve.methods.get import get_internal
 from werkzeug.utils import secure_filename
 from flask_babel import gettext
+from bson import ObjectId
 
 from newsroom.navigations.navigations import get_navigations_by_company
 from newsroom.wire import blueprint
@@ -43,6 +44,24 @@ def get_view_data():
     }
 
 
+def get_home_data():
+    cards = [
+        {'label': 'Something', 'type': '6-text-only', 'config': {'product': '5a23c1131d41c82b8dd4267d', 'size': 6}},
+        {'label': 'Other Stories', 'type': '4-picture-text',
+         'config': {'product': '5a23c1131d41c82b8dd4267d', 'size': 4}},
+    ]
+
+    itemsByCard = {}
+    for card in cards:
+        itemsByCard[card['label']] = superdesk.get_resource_service('wire_search').\
+            get_product_items(ObjectId(card['config']['product']), card['config']['size'])
+
+    return {
+        'cards': cards,
+        'itemsByCard': itemsByCard
+    }
+
+
 def get_previous_versions(item):
     if item.get('ancestors'):
         return sorted(
@@ -56,7 +75,8 @@ def get_previous_versions(item):
 @blueprint.route('/')
 @login_required
 def index():
-    return flask.render_template('wire_index.html', data=get_view_data())
+    # return flask.render_template('wire_index.html', data=get_view_data())
+    return flask.render_template('home.html', data=get_home_data())
 
 
 @blueprint.route('/bookmarks')

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -45,12 +45,6 @@ def get_view_data():
 
 
 def get_home_data():
-    # cards = [
-    #     {'label': 'Something', 'type': '6-text-only', 'config': {'product': '5a23c1131d41c82b8dd4267d', 'size': 6}},
-    #     {'label': 'Other Stories', 'type': '4-picture-text',
-    #      'config': {'product': '5a23c1131d41c82b8dd4267d', 'size': 4}},
-    # ]
-
     cards = list(superdesk.get_resource_service('cards').get(None, None))
 
     itemsByCard = {}

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -1,0 +1,63 @@
+from bson import ObjectId
+from flask import json
+from pytest import fixture
+
+from .test_users import test_login_succeeds_for_admin, init as user_init
+
+
+@fixture(autouse=True)
+def init(app):
+    user_init(app)
+    app.data.insert('cards', [{
+        '_id': ObjectId('59b4c5c61d41c8d736852fbf'),
+        'label': 'Sport',
+        'type': '6-text-only',
+        'config': {
+            'product': '5a23c1131d41c82b8dd4267d',
+            'size': 6,
+        }
+    }])
+
+
+def test_card_list_fails_for_anonymous_user(client):
+    response = client.get('/cards')
+    assert response.status_code == 302
+
+
+def test_save_and_return_cards(client):
+    test_login_succeeds_for_admin(client)
+    # Save a new card
+    client.post('/cards/new', data=json.dumps({
+        '_id': ObjectId('59b4c5c61d41c8d736852fbf'),
+        'label': 'Local News',
+        'type': '4-picture-text',
+        'config': {
+            'product': '5a23c1131d41c82b8dd4267d',
+            'size': 4,
+        }
+    }), content_type='application/json')
+
+    response = client.get('/cards')
+    assert 'Local' in response.get_data(as_text=True)
+
+
+def test_update_card(client):
+    test_login_succeeds_for_admin(client)
+
+    client.post('/cards/59b4c5c61d41c8d736852fbf/',
+                data=json.dumps({'label': 'Sport',
+                                 'type': '4-picture-text'}),
+                content_type='application/json')
+
+    response = client.get('/cards')
+    assert '4-picture-text' in response.get_data(as_text=True)
+
+
+def test_delete_card_succeeds(client):
+    test_login_succeeds_for_admin(client)
+
+    client.delete('/cards/59b4c5c61d41c8d736852fbf')
+
+    response = client.get('/cards')
+    data = json.loads(response.get_data())
+    assert 0 == len(data)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
         user_profile_js: './assets/user-profile/index.js',
         newsroom_css: './assets/style.js',
         wire_js: './assets/wire/index.js',
+        home_js: './assets/home/index.js',
         notifications_js: './assets/notifications/index.js',
         vendor: [
             'alertifyjs',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
         users_js: './assets/users/index.js',
         products_js: './assets/products/index.js',
         navigations_js: './assets/navigations/index.js',
+        cards_js: './assets/cards/index.js',
         user_profile_js: './assets/user-profile/index.js',
         newsroom_css: './assets/style.js',
         wire_js: './assets/wire/index.js',


### PR DESCRIPTION
This PR includes:
- Home app for home page as the defauld landing page. Wire is accessable from sidebar icon.
- React components for various card types.
- A basic card management in settings page.

I have left the following functionality to the next PR:
- Links for `More News` buttons per card
- Story details page once the card is clicked
- Ordering of cards in settings page

Also for now there's no auto resfresh of cards on home page. 