### PR TITLE
fix picture usage in home widgets

### DIFF
--- a/assets/home/components/MediaGalleryCard.jsx
+++ b/assets/home/components/MediaGalleryCard.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { gettext, shortDate } from 'utils';
-import { getPicture, getPreviewRendition, getCaption } from 'wire/utils';
+import { getPicture, getThumbnailRendition, getCaption } from 'wire/utils';
 import MoreNewsButton from './MoreNewsButton';
 
 const getMediaPanel = (item, picture, openItem) => {
-    
-    const rendition = getPreviewRendition(picture);
+
+    const rendition = getThumbnailRendition(picture);
     const imageUrl = rendition && rendition.href;
     const caption = rendition && getCaption(picture);
 
@@ -14,11 +14,11 @@ const getMediaPanel = (item, picture, openItem) => {
         <div className='card card--home card--gallery' onClick={() => openItem(item)}>
             <img className='card-img-top' src={imageUrl} alt={caption} />
             <div className='card-body'>
-                <div className='wire-articles__item__meta'>                                
-                    <div className='wire-articles__item__meta-info'>                                    
+                <div className='wire-articles__item__meta'>
+                    <div className='wire-articles__item__meta-info'>
                         <span>{gettext('Source: {{ source }}', {source: item.source})} {'//'} {shortDate(item.versioncreated)}</span>
                     </div>
-                </div>                        
+                </div>
                 <h4 className='card-title'>{item.headline}</h4>
             </div>
         </div>

--- a/assets/home/components/PictureTextCard.jsx
+++ b/assets/home/components/PictureTextCard.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { gettext, shortDate, wordCount } from 'utils';
-import { getPicture, getPreviewRendition, getCaption } from 'wire/utils';
+import { getPicture, getThumbnailRendition, getCaption } from 'wire/utils';
 import MoreNewsButton from './MoreNewsButton';
 
 const getPictureTextPanel = (item, picture, openItem) => {
-    const rendition = getPreviewRendition(picture);
+    const rendition = getThumbnailRendition(picture);
     const imageUrl = rendition && rendition.href;
     const caption = rendition && getCaption(picture);
 

--- a/assets/home/components/TopNewsTwoByTwoCard.jsx
+++ b/assets/home/components/TopNewsTwoByTwoCard.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { gettext, shortDate, fullDate, wordCount } from 'utils';
-import { getPicture, getPreviewRendition, getCaption } from 'wire/utils';
+import { getPicture, getPreviewRendition, getThumbnailRendition, getCaption } from 'wire/utils';
 import MoreNewsButton from './MoreNewsButton';
 
 const getTopNewsLeftPanel = (item, picture, openItem) => {
@@ -39,15 +39,15 @@ const getTopNewsLeftPanel = (item, picture, openItem) => {
                 <div className='wire-articles__item__text'>
                     <p className='card-text'>{item.description_text}</p>
                 </div>
-            </div>                        
+            </div>
         </div>
     </div>
     );
 };
-  
+
 const getTopNewsRightPanel = (item, picture, openItem) => {
 
-    const rendition = getPreviewRendition(picture);
+    const rendition = getThumbnailRendition(picture);
     const imageUrl = rendition && rendition.href;
     const caption = rendition && getCaption(picture);
 

--- a/assets/wire/utils.js
+++ b/assets/wire/utils.js
@@ -73,7 +73,7 @@ export function getPicture(item) {
  * @return {Object}
  */
 export function getThumbnailRendition(picture) {
-    return get(picture, 'renditions.4-3', get(picture, 'renditions.thumbnail'));
+    return get(picture, 'renditions.viewImage', get(picture, 'renditions.thumbnail'));
 }
 
 /**
@@ -83,7 +83,7 @@ export function getThumbnailRendition(picture) {
  * @return {Object}
  */
 export function getPreviewRendition(picture) {
-    return get(picture, 'renditions.4-3', get(picture, 'renditions.viewImage'));
+    return get(picture, 'renditions.baseImage', get(picture, 'renditions.viewImage'));
 }
 
 /**

--- a/newsroom/push.py
+++ b/newsroom/push.py
@@ -177,7 +177,7 @@ def push_binary():
     binary = media  # what we store
     content_type = media.content_type
 
-    MIN_WIDTH = 400
+    MIN_WIDTH = 650
     MAX_WIDTH = 2000
     MIN_HEIGHT = 200
     MAX_HEIGHT = 1000


### PR DESCRIPTION
there will be thumbnail and viewImage rendition without watermark,
those should be used for wire list and home views with small images.

so utils.getThumbnailRendition will be without watermark, utils.getPreviewRendition
should have it.

SDAN-138