### PR TITLE
fix(renditions): generate custom renditions with watermark

### DIFF
--- a/assets/home/components/TopNewsOneByOneCard.jsx
+++ b/assets/home/components/TopNewsOneByOneCard.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { gettext, shortDate, fullDate, wordCount } from 'utils';
-import { getPicture, getPreviewRendition, getCaption } from 'wire/utils';
+import { getPicture, getThumbnailRendition, getCaption } from 'wire/utils';
 import MoreNewsButton from './MoreNewsButton';
 
 const getTopNewsPanel = (item, picture, openItem) => {
     
-    const rendition = getPreviewRendition(picture);
+    const rendition = getThumbnailRendition(picture, true);
     const imageUrl = rendition && rendition.href;
     const caption = rendition && getCaption(picture);
 

--- a/assets/home/components/TopNewsTwoByTwoCard.jsx
+++ b/assets/home/components/TopNewsTwoByTwoCard.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { gettext, shortDate, fullDate, wordCount } from 'utils';
-import { getPicture, getPreviewRendition, getThumbnailRendition, getCaption } from 'wire/utils';
+import { getPicture, getThumbnailRendition, getCaption } from 'wire/utils';
 import MoreNewsButton from './MoreNewsButton';
 
 const getTopNewsLeftPanel = (item, picture, openItem) => {
 
-    const rendition = getPreviewRendition(picture);
+    const rendition = getThumbnailRendition(picture, true);
     const imageUrl = rendition && rendition.href;
     const caption = rendition && getCaption(picture);
 

--- a/assets/wire/utils.js
+++ b/assets/wire/utils.js
@@ -70,10 +70,12 @@ export function getPicture(item) {
  * Get picture thumbnail rendition specs
  *
  * @param {Object} picture
+ * @param {Boolean} large
  * @return {Object}
  */
-export function getThumbnailRendition(picture) {
-    return get(picture, 'renditions.viewImage', get(picture, 'renditions.thumbnail'));
+export function getThumbnailRendition(picture, large) {
+    const rendition = large ? 'renditions._newsroom_thumbnail_large' : 'renditions._newsroom_thumbnail';
+    return get(picture, rendition, get(picture, 'renditions.thumbnail'));
 }
 
 /**
@@ -83,7 +85,7 @@ export function getThumbnailRendition(picture) {
  * @return {Object}
  */
 export function getPreviewRendition(picture) {
-    return get(picture, 'renditions.baseImage', get(picture, 'renditions.viewImage'));
+    return get(picture, 'renditions._newsroom_view', get(picture, 'renditions.viewImage'));
 }
 
 /**
@@ -93,7 +95,7 @@ export function getPreviewRendition(picture) {
  * @return {Object}
  */
 export function getDetailRendition(picture) {
-    return get(picture, 'renditions.baseImage');
+    return get(picture, 'renditions._newsroom_base', get(picture, 'renditions.baseImage'));
 }
 
 /**

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ Flask-WTF==0.14.2
 flask-limiter==0.9.5.1
 Flask-Cache==0.13.1
 honcho==1.0.1
-superdesk-core==1.9
+superdesk-core==1.13


### PR DESCRIPTION
new renditions:
    - _newsroom_thumbnail from 4-3 crop without watermark resized
    - _newsroom_thumbnail_large from 4-3 crom with watermark
    - _newsroom_view for viewImage rendition with watermark
    - _newsroom_base for baseImage renditino with watermark

user those renditions if available.

SDAN-192