### PR TITLE
[SDAN-197] - Hide count on the main pages

### DIFF
--- a/assets/wire/components/SearchResultsInfo.jsx
+++ b/assets/wire/components/SearchResultsInfo.jsx
@@ -21,10 +21,11 @@ function SearchResultsInfo({
     newsOnly,
 }) {
     const isFollowing = user && activeTopic;
+    const displayTotalItems = bookmarks || !isEmpty(searchCriteria)  || activeTopic;
     return (
         <div className="d-flex mt-1 mt-sm-3 px-3 align-items-center flex-wrap flex-sm-nowrap">
             <div className="navbar-text search-results-info">
-                <span className="search-results-info__num">{totalItems}</span>
+                {displayTotalItems && <span className="search-results-info__num">{totalItems}</span>}
                 {query && (
                     <span className="search-results-info__text">
                         {gettext('search results for:')}<br />

--- a/assets/wire/components/WireApp.jsx
+++ b/assets/wire/components/WireApp.jsx
@@ -262,6 +262,7 @@ const mapStateToProps = (state) => ({
     navigations: get(state, 'wire.navigations', []),
     activeNavigation: get(state, 'wire.activeNavigation', null),
     newsOnly: !!state.newsOnly,
+    bookmarks: state.bookmarks,
 });
 
 const mapDispatchToProps = (dispatch) => ({


### PR DESCRIPTION
- the number of items should not be displayed on the "main" pages - i.e. the Wire home page, pages from navigation
- the number of items should be displayed for:
-- search results
-- when filters are applied
-- topics
-- bookmarks