### PR TITLE
add initial theme support

### DIFF
--- a/newsroom/default_settings.py
+++ b/newsroom/default_settings.py
@@ -177,3 +177,5 @@ SERVICES = [
 
 CLIENT_TIME_FORMAT = 'HH:mm'
 CLIENT_DATE_FORMAT = 'DD/MM/YYYY'
+
+WATERMARK_IMAGE = os.path.join(os.path.dirname(__file__), 'static', 'watermark.png')

--- a/newsroom/push.py
+++ b/newsroom/push.py
@@ -1,6 +1,5 @@
 
 import io
-import os
 import hmac
 import flask
 import logging
@@ -198,7 +197,8 @@ def generate_thumbnails(item):
         return
 
     # use 4-3 rendition for generated thumbs
-    rendition = picture.get('renditions', {}).get('4-3', 'viewImage')
+    renditions = picture.get('renditions', {})
+    rendition = renditions.get('4-3', renditions.get('viewImage'))
     if not rendition:
         return
 
@@ -247,9 +247,11 @@ def _get_thumbnail(image):
 
 def _get_watermark(image):
     image = image.copy()
+    if not app.config.get('WATERMARK_IMAGE'):
+        return image
     if image.mode != 'RGBA':
         image = image.convert('RGBA')
-    with open(os.path.join(app.static_folder, 'watermark.png'), mode='rb') as watermark_binary:
+    with open(app.config['WATERMARK_IMAGE'], mode='rb') as watermark_binary:
         watermark_image = Image.open(watermark_binary)
         set_opacity(watermark_image, 0.3)
         watermark_layer = Image.new('RGBA', image.size)

--- a/newsroom/templates/layout.html
+++ b/newsroom/templates/layout.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/alertifyjs@1.11.0/build/css/themes/bootstrap.min.css"/>
 
     <link rel="icon" type="image/x-icon"
-        href="{{ url_for('static', filename='favicon.ico') }}">
+        href="{{ url_for('theme', filename='favicon.ico') }}">
 
 {{ javascript_tag('common') | safe }}
 {{ javascript_tag('newsroom_css') | safe }}
@@ -21,11 +21,8 @@
 <body>
 
 <div class="newsroomWrap">
-
     <nav class="main navbar justify-content-start align-items-stretch">
-        <div class="navbar__logo px-1">
-            <img src="{{ url_for('static', filename = 'logo.svg') }}" width="90"/>
-        </div>
+        {% include 'logo.html' %}
         <div class="navbar-brand d-flex align-items-center ml-2 ml-sm-1 mr-0 mr-sm-4">
             <nav>
                 <a class="breadcrumb-item text-white"  href="{{ url_for('wire.index') }}">{{ config.SITE_NAME }}</a>

--- a/newsroom/templates/login.html
+++ b/newsroom/templates/login.html
@@ -8,7 +8,7 @@
             <div class="card border-0 bg-white box-shadow--z1">
                 <div class="card-header pt-4 border-0 bg-white">
                     <div class="text-center mb-4">
-                        <img src="{{ url_for('static', filename = 'logo-aap.svg') }}" width="120"/>
+                        {% include 'login_logo.html' %}
                     </div>
                     <h5 class="mb-0">{{ gettext("Login") }}</h5>
                 </div>

--- a/newsroom/templates/login_logo.html
+++ b/newsroom/templates/login_logo.html
@@ -1,0 +1,1 @@
+<img src="{{ url_for('static', filename = 'logo-aap.svg') }}" width="120"/>

--- a/newsroom/templates/logo.html
+++ b/newsroom/templates/logo.html
@@ -1,0 +1,3 @@
+<div class="navbar__logo px-1">
+    <img src="{{ url_for('theme', filename = 'logo.svg') }}" width="90"/>
+</div>


### PR DESCRIPTION
use `url_for('theme', filename='logo.svg')` to get the file
either from `theme` folder or `newsroom.static`

templates are loaded from `theme` or `newsroom.templates`

settings are updated using `./settings.py` file if present