### PR TITLE
[SDAN-215] - Moving filters from post-filters

### DIFF
--- a/newsroom/default_settings.py
+++ b/newsroom/default_settings.py
@@ -133,6 +133,11 @@ CACHE_REDIS_URL = os.environ.get('REDIS_URL', 'redis://localhost:6379')
 RECAPTCHA_PUBLIC_KEY = os.environ.get('RECAPTCHA_PUBLIC_KEY')
 RECAPTCHA_PRIVATE_KEY = os.environ.get('RECAPTCHA_PRIVATE_KEY')
 
+# Filter tab behaviour
+# If true, aggregations will be against all content all the time
+# If false, aggregations will change by filters applied
+FILTER_BY_POST_FILTER = False
+
 # Base64 Encoded Token
 AAPPHOTOS_TOKEN = os.environ.get('AAPPHOTOS_TOKEN')
 

--- a/newsroom/wire/search.py
+++ b/newsroom/wire/search.py
@@ -198,7 +198,7 @@ class WireSearchService(newsroom.Service):
             filters = json.loads(req.args['filter'])
 
         if not app.config.get('FILTER_BY_POST_FILTER', False):
-            if filters and not app.config.get('FILTER_BY_POST_FILTER', False):
+            if filters:
                 query['bool']['must'] += _filter_terms(filters)
 
             if req.args.get('created_from') or req.args.get('created_to'):


### PR DESCRIPTION
Created a new setting `FILTER_BY_POST_FILTER` to control the aggregations on the results. For AAP we can set it to `False` so they get renewed aggs for evey new filter