### PR TITLE
[SDAN-223] - Fixing copy function when the panel is opened

### DIFF
--- a/assets/wire/actions.js
+++ b/assets/wire/actions.js
@@ -26,6 +26,14 @@ export function preview(item) {
     return {type: PREVIEW_ITEM, item};
 }
 
+
+export function previewAndCopy(item) {
+    return (dispatch) => {
+        dispatch(previewItem(item));
+        window.setTimeout(() => dispatch(copyPreviewContents(item)), 200);
+    };
+}
+
 export function previewItem(item) {
     return (dispatch, getState) => {
         markItemAsRead(item, getState());

--- a/assets/wire/item-actions.js
+++ b/assets/wire/item-actions.js
@@ -1,7 +1,7 @@
 import {gettext} from '../utils';
 import {
     bookmarkItems,
-    copyPreviewContents,
+    previewAndCopy,
     downloadItems,
     openItem,
     printItem,
@@ -37,7 +37,7 @@ export function getItemActions(dispatch) {
             name: gettext('Copy'),
             icon: 'copy',
             visited: (user, item) => user && item && item.copies &&  item.copies.includes(user),
-            action: (item) => dispatch(copyPreviewContents(item)),
+            action: (item) => dispatch(previewAndCopy(item)),
         },
         {
             name: gettext('Download'),


### PR DESCRIPTION
At the moment copy relies on dom element for preview panel to exist. This solution opens the preview panel before copy takes place.