### PR TITLE
Active item makes the list jump

### DIFF
--- a/assets/wire/components/WireListItem.jsx
+++ b/assets/wire/components/WireListItem.jsx
@@ -39,12 +39,6 @@ class WireListItem extends React.Component {
         this.setState({previousVersions: !this.state.previousVersions});
     }
 
-    componentDidUpdate(nextProps) {
-        if (nextProps.isActive) {
-            this.articleElem.focus();
-        }
-    }
-
     componentDidMount() {
         if (this.props.isActive) {
             this.articleElem.focus();


### PR DESCRIPTION
`focus` on `componentDidUpdate` was making the scroll position to jump momentarily when a new page of results are loaded. Which was causing user to double click the wrong item.
[SDAN-224]