### PR TITLE
Slugline and genre changes

### DIFF
--- a/assets/home/components/TopNewsOneByOneCard.jsx
+++ b/assets/home/components/TopNewsOneByOneCard.jsx
@@ -22,7 +22,6 @@ const getTopNewsPanel = (item, picture, openItem, cardId) => {
                     source={item.source}
                     versioncreated={item.versioncreated}
                     displayDivider={false}
-                    slugline={item.slugline}
                 />
                 <div className='wire-articles__item__text'>
                     <p className='card-text small'>{item.description_text}</p>

--- a/assets/wire/components/PreviewTags.jsx
+++ b/assets/wire/components/PreviewTags.jsx
@@ -29,7 +29,7 @@ function PreviewTags({item, isItemDetail}) {
             {genres &&
                 <div className='column__preview__tags__column'>
                     <span className='wire-column__preview__tags__headline'>
-                        {gettext('Genre')}</span>
+                        {gettext('Content Type')}</span>
                     {genres}
                 </div>
             }

--- a/newsroom/templates/wire_item.html
+++ b/newsroom/templates/wire_item.html
@@ -80,7 +80,7 @@
                         {% endif %}
                         {% if item.genre %}
                         <div class="column__preview__tags__column">
-                            <span class="wire-column__preview__tags__headline">{{ _('Genre') }}</span>
+                            <span class="wire-column__preview__tags__headline">{{ _('Content Type') }}</span>
                             {% for genre in item.genre %}
                             <a class="wire-column__preview__tag"
                                 href='{{ url_for('wire.index') }}?q=genre.name:"{{ genre.name }}"'

--- a/newsroom/templates/wire_item_print.html
+++ b/newsroom/templates/wire_item_print.html
@@ -25,7 +25,7 @@
                 <dd>{{ item.subject|join(', ', attribute='name')}}</dd>
                 {% endif %}
                 {% if item.genre %}
-                <dt>{{ _('Genre') }}</dt>
+                <dt>{{ _('Content Type') }}</dt>
                 <dd>{{ item.genre|join(', ', attribute='name')}}</dd>
                 {% endif %}
             </dl>


### PR DESCRIPTION
[SDAN-226] - Rename "Genre" to "Content type" in story preview and detail
[SDAN-225] - Remove slugline from 1x1 Top News Home page card