### PR TITLE
[SDAN-257] - Making kill notices searchable

### DIFF
--- a/assets/wire/components/ItemDetails.jsx
+++ b/assets/wire/components/ItemDetails.jsx
@@ -6,7 +6,7 @@ import PreviewTags from './PreviewTags';
 import ListItemPreviousVersions from './ListItemPreviousVersions';
 import ListItemNextVersion from './ListItemNextVersion';
 import { gettext, fullDate, formatHTML } from 'utils';
-import { getPicture, getDetailRendition, showItemVersions, getCaption } from 'wire/utils';
+import { getPicture, getDetailRendition, showItemVersions, getCaption, isKilled } from 'wire/utils';
 
 function ItemDetails({item, user, actions, onClose}) {
     const picture = getPicture(item);
@@ -26,7 +26,7 @@ function ItemDetails({item, user, actions, onClose}) {
 
             <article id='preview-article' className="wire-column__preview__content--item-detal-wrap">
                 <div className="wire-column__preview__content">
-                    {getDetailRendition(picture) && (
+                    {getDetailRendition(picture) && !isKilled(item) && (
                         <figure className="wire-column__preview__image">
                             <span>
                                 <img src={getDetailRendition(picture).href} />

--- a/assets/wire/components/Preview.jsx
+++ b/assets/wire/components/Preview.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { gettext, fullDate, formatHTML } from 'utils';
-import { getPicture, getPreviewRendition, showItemVersions, getCaption, isEqualItem } from 'wire/utils';
+import { getPicture, getPreviewRendition, showItemVersions, getCaption, isEqualItem, isKilled } from 'wire/utils';
 import ListItemPreviousVersions from './ListItemPreviousVersions';
 import PreviewActionButtons from './PreviewActionButtons';
 import PreviewTags from './PreviewTags';
@@ -67,7 +67,7 @@ class Preview extends React.PureComponent {
                             )}
                         </p>
                     )}
-                    {getPreviewRendition(picture) && (
+                    {getPreviewRendition(picture) && !isKilled(item) && (
                         <figure className='wire-column__preview__image'>
                             <img src={getPreviewRendition(picture).href} />
                             <figcaption className='wire-column__preview__caption'>{getCaption(picture)}</figcaption>

--- a/assets/wire/components/WireListItem.jsx
+++ b/assets/wire/components/WireListItem.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { gettext, shortDate, fullDate, wordCount } from 'utils';
-import { getPicture, getThumbnailRendition, showItemVersions, shortText } from 'wire/utils';
+import { getPicture, getThumbnailRendition, showItemVersions, shortText, isKilled } from 'wire/utils';
 
 import ActionList from 'components/ActionList';
 import ActionButton from 'components/ActionButton';
@@ -120,7 +120,7 @@ class WireListItem extends React.Component {
                         )}
                     </div>
 
-                    {isExtended && getThumbnailRendition(picture) && (
+                    {isExtended && !isKilled(item) && getThumbnailRendition(picture) && (
                         <div className="wire-articles__item-image">
                             <figure>
                                 <img src={getThumbnailRendition(picture).href} />

--- a/newsroom/email.py
+++ b/newsroom/email.py
@@ -109,3 +109,12 @@ def send_history_match_notification_email(user, item):
         url=url)
 
     send_email(to=recipients, subject=subject, text_body=text_body)
+
+
+def send_item_killed_notification_email(user, item):
+    formatter = current_app.download_formatters['text']['formatter']
+    recipients = [user['email']]
+    subject = gettext('Kill/Takedown notice')
+    text_body = formatter.format_item(item)
+
+    send_email(to=recipients, subject=subject, text_body=text_body)

--- a/newsroom/push.py
+++ b/newsroom/push.py
@@ -13,7 +13,8 @@ from superdesk.text_utils import get_word_count
 from newsroom.notifications import push_notification
 from newsroom.topics.topics import get_notification_topics
 from newsroom.utils import query_resource, parse_dates
-from newsroom.email import send_new_item_notification_email, send_history_match_notification_email
+from newsroom.email import send_new_item_notification_email, \
+    send_history_match_notification_email, send_item_killed_notification_email
 from newsroom.history import get_history_users
 from newsroom.wire.views import HOME_ITEMS_CACHE_KEY
 from newsroom.upload import ASSETS_RESOURCE
@@ -95,7 +96,7 @@ def push():
 
 
 def notify_new_item(item, check_topics=True):
-    if item.get('pubstatus') == 'canceled' or item.get('type') == 'composite':
+    if item.get('type') == 'composite':
         return
 
     lookup = {'is_enabled': True}
@@ -141,8 +142,11 @@ def notify_user_matches(item, users_dict, companies_dict, user_ids, company_ids)
 def send_user_notification_emails(item, user_matches, users):
     for user_id in user_matches:
         user = users.get(str(user_id))
-        if user.get('receive_email'):
-            send_history_match_notification_email(user, item=item)
+        if item.get('pubstatus') == 'canceled':
+            send_item_killed_notification_email(user, item=item)
+        else:
+            if user.get('receive_email'):
+                send_history_match_notification_email(user, item=item)
 
 
 def notify_topic_matches(item, users_dict, companies_dict):

--- a/newsroom/wire/search.py
+++ b/newsroom/wire/search.py
@@ -182,7 +182,6 @@ class WireSearchService(newsroom.Service):
 
         if req.args.get('q'):
             query['bool']['must'].append(_query_string(req.args['q']))
-            # query['bool']['must_not'].append({'term': {'pubstatus': 'canceled'}})
 
         if req.args.get('newsOnly'):
             for f in app.config.get('NEWS_ONLY_FILTERS', []):
@@ -243,7 +242,6 @@ class WireSearchService(newsroom.Service):
             query['bool']['should'].append(_query_string(product['query']))
 
         query['bool']['minimum_should_match'] = 1
-        query['bool']['must_not'].append({'term': {'pubstatus': 'canceled'}})
 
         source = {'query': query}
         source['sort'] = [{'versioncreated': 'desc'}]
@@ -269,7 +267,6 @@ class WireSearchService(newsroom.Service):
                 'must_not': [
                     {'term': {'type': 'composite'}},
                     {'constant_score': {'filter': {'exists': {'field': 'nextversion'}}}},
-                    {'term': {'pubstatus': 'canceled'}}
                 ],
                 'must': [
                     {'term': {'_id': item_id}}
@@ -347,7 +344,6 @@ class WireSearchService(newsroom.Service):
                 'bool': {
                     'must_not': [
                         {'term': {'type': 'composite'}},
-                        {'term': {'pubstatus': 'canceled'}}
                     ],
                     'must': [
                         {'terms': {'_id': item_ids}}
@@ -364,7 +360,7 @@ class WireSearchService(newsroom.Service):
             return super().get(req, None)
 
         except Exception as exc:
-            logger.error('Error in get_matching_bookmarks for query: {}'.format(json.dumps(source)),
+            logger.error('Error in get_items for query: {}'.format(json.dumps(source)),
                          exc, exc_info=True)
 
     def get_matching_bookmarks(self, item_ids, active_users, active_companies):

--- a/newsroom/wire/search.py
+++ b/newsroom/wire/search.py
@@ -182,7 +182,7 @@ class WireSearchService(newsroom.Service):
 
         if req.args.get('q'):
             query['bool']['must'].append(_query_string(req.args['q']))
-            query['bool']['must_not'].append({'term': {'pubstatus': 'canceled'}})
+            # query['bool']['must_not'].append({'term': {'pubstatus': 'canceled'}})
 
         if req.args.get('newsOnly'):
             for f in app.config.get('NEWS_ONLY_FILTERS', []):

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -112,11 +112,11 @@ def test_search_filters_items_with_updates(client, app):
     assert 'tag:weather' not in [item['_id'] for item in data['_items']]
 
 
-def test_search_filters_killed_items(client, app):
+def test_search_includes_killed_items(client, app):
     app.data.insert('items', [{'_id': 'foo', 'pubstatus': 'canceled', 'headline': 'killed'}])
     resp = client.get('/search?q=headline:killed')
     data = json.loads(resp.get_data())
-    assert 0 == len(data['_items'])
+    assert 1 == len(data['_items'])
 
 
 def test_search_by_products_id(client, app):


### PR DESCRIPTION
- Kill stories (i.e. with `{pubstatus: canceled}`) are visible in the search results
- Images will be hidden in kill stories
- Kill stories has the same actions (i.e. download, share, copy) as the normal stories
- Users will get top-menu notifications for kill stories
- Users will also get email notification for the kill regardless of their `receive email` preference if they engaged with the original story