### PR TITLE
[SDAN-262] - Newsonly should work for general search only

### DIFF
--- a/newsroom/wire/search.py
+++ b/newsroom/wire/search.py
@@ -184,7 +184,7 @@ class WireSearchService(newsroom.Service):
             query['bool']['must'].append(_query_string(req.args['q']))
             query['bool']['must_not'].append({'term': {'pubstatus': 'canceled'}})
 
-        if req.args.get('newsOnly'):
+        if req.args.get('newsOnly') and not req.args.get('navigation'):
             for f in app.config.get('NEWS_ONLY_FILTERS', []):
                 query['bool']['must_not'].append(f)
 


### PR DESCRIPTION
If a `navigation` is selected newsonly shouldn't get into effect