### PR TITLE
[SDAN-266] - Header section of the newsroom is getting chopped

### DIFF
--- a/assets/home/components/CardRow.jsx
+++ b/assets/home/components/CardRow.jsx
@@ -10,7 +10,7 @@ class CardRow extends React.Component {
 
     componentDidMount() {
         if (this.props.isActive) {
-            this.cardElem.scrollIntoView();
+            this.cardElem.scrollIntoView({behavior: 'instant', block: 'end', inline: 'nearest'});
         }
     }
 


### PR DESCRIPTION
Happens when a story is opened and closed on home page