### PR TITLE
Product type field is introduced for agenda and wire

### DIFF
--- a/assets/products/components/EditProduct.jsx
+++ b/assets/products/components/EditProduct.jsx
@@ -2,9 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import TextInput from 'components/TextInput';
 import CheckboxInput from 'components/CheckboxInput';
+import SelectInput from 'components/SelectInput';
 
 import { gettext, getProductQuery } from 'utils';
 import EditPanel from '../../components/EditPanel';
+
+const productTypes = [
+    {value: 'wire', text: gettext('Wire')},
+    {value: 'agenda', text: gettext('Agenda')},
+];
 
 
 class EditProduct extends React.Component {
@@ -103,7 +109,7 @@ class EditProduct extends React.Component {
                                             onChange={this.props.onChange}
                                         />
                                         {this.props.product.sd_product_id &&
-                                        <a href={`/wire?q=products.code:${this.props.product.sd_product_id}`} target="_blank"
+                                        <a href={`/${this.props.product.product_type || 'wire'}?q=products.code:${this.props.product.sd_product_id}`} target="_blank"
                                             className='btn btn-outline-secondary float-right mt-2'>{gettext('Test product id')}
                                         </a>}
                                     </div>
@@ -117,10 +123,18 @@ class EditProduct extends React.Component {
                                             onChange={this.props.onChange}
                                         />
                                         {this.props.product.query &&
-                                        <a href={`/wire?q=${this.props.product.query}`} target="_blank"
+                                        <a href={`/${this.props.product.product_type || 'wire'}?q=${this.props.product.query}`} target="_blank"
                                             className='btn btn-outline-secondary float-right mt-3'>{gettext('Test query')}
                                         </a>}
                                     </div>
+
+                                    <SelectInput
+                                        name='product_type'
+                                        label={gettext('Product Type')}
+                                        value={this.props.product.product_type}
+                                        options={productTypes}
+                                        onChange={this.props.onChange}
+                                        error={this.props.errors ? this.props.errors.product_type : null} />
 
                                     <CheckboxInput
                                         name='is_enabled'

--- a/assets/products/components/ProductList.jsx
+++ b/assets/products/components/ProductList.jsx
@@ -23,6 +23,7 @@ function ProductList({products, onClick, activeProductId}) {
                             <th>{ gettext('Status') }</th>
                             <th>{ gettext('Superdesk Product Id') }</th>
                             <th>{ gettext('Query') }</th>
+                            <th>{ gettext('Product Type') }</th>
                             <th>{ gettext('Created On') }</th>
                         </tr>
                     </thead>

--- a/assets/products/components/ProductListItem.jsx
+++ b/assets/products/components/ProductListItem.jsx
@@ -12,6 +12,7 @@ function ProductListItem({product, isActive, onClick}) {
             <td>{(product.is_enabled ? gettext('Enabled') : gettext('Disabled'))}</td>
             <td>{gettext(product.sd_product_id)}</td>
             <td>{gettext(product.query)}</td>
+            <td>{gettext(product.product_type)}</td>
             <td>{shortDate(product._created)}</td>
         </tr>
     );

--- a/assets/wire/components/SearchSidebar.jsx
+++ b/assets/wire/components/SearchSidebar.jsx
@@ -11,6 +11,10 @@ import {
     resetFilter,
 } from 'wire/actions';
 
+import {
+    toggleNavigation as toggleAgendaNavigation
+} from 'agenda/actions';
+
 import TopicsTab from './TopicsTab';
 import FiltersTab from './filters/FiltersTab';
 import NavigationTab from './filters/NavigationTab';
@@ -34,7 +38,8 @@ class SearchSidebar extends React.Component {
 
     toggleNavigation(event, navigation) {
         event.preventDefault();
-        this.props.dispatch(toggleNavigation(navigation));
+        const fn = isWireContext() ? toggleNavigation : toggleAgendaNavigation;
+        this.props.dispatch(fn(navigation));
     }
 
     toggleFilter(event, field, value, single) {

--- a/newsroom/agenda/agenda.py
+++ b/newsroom/agenda/agenda.py
@@ -89,6 +89,18 @@ class AgendaResource(newsroom.Resource):
     schema['prints'] = Resource.not_analyzed_field('list')  # list of user ids who printed this item
     schema['copies'] = Resource.not_analyzed_field('list')  # list of user ids who copied this item
 
+    # matching products from superdesk
+    schema['products'] = {
+        'type': 'list',
+        'mapping': {
+            'type': 'object',
+            'properties': {
+                'code': not_analyzed,
+                'name': not_analyzed
+            }
+        }
+    }
+
     resource_methods = ['GET']
     datasource = {
         'source': 'agenda',

--- a/newsroom/agenda/views.py
+++ b/newsroom/agenda/views.py
@@ -49,5 +49,6 @@ def get_view_data():
         'company': str(user['company']) if user and user.get('company') else None,
         'topics': [t for t in topics if t.get('topic_type') == 'agenda'],
         'formats': [{'format': f['format'], 'name': f['name']} for f in app.download_formatters.values()],
-        'navigations': get_navigations_by_company(str(user['company']) if user and user.get('company') else None),
+        'navigations': get_navigations_by_company(str(user['company']) if user and user.get('company') else None,
+                                                  product_type='agenda'),
     }

--- a/newsroom/navigations/navigations.py
+++ b/newsroom/navigations/navigations.py
@@ -36,12 +36,12 @@ class NavigationsService(newsroom.Service):
     pass
 
 
-def get_navigations_by_company(company_id):
+def get_navigations_by_company(company_id, product_type='wire'):
     """
     Returns list of navigations for given company id
     Navigations will contain the list of product ids
     """
-    product_lookup = {'is_enabled': True, 'companies': str(company_id)}
+    product_lookup = {'is_enabled': True, 'companies': str(company_id), 'product_type': product_type}
     products = list(superdesk.get_resource_service('products').get(req=None, lookup=product_lookup))
 
     # Get the navigation ids used across products

--- a/newsroom/products/products.py
+++ b/newsroom/products/products.py
@@ -33,6 +33,11 @@ class ProductsResource(newsroom.Resource):
             'type': 'list',
             'nullable': True,
         },
+        'product_type': {
+            'type': 'string',
+            'allowed': ['agenda', 'wire'],
+            'default': 'wire'
+        },
     }
     datasource = {
         'source': 'products',

--- a/newsroom/products/views.py
+++ b/newsroom/products/views.py
@@ -77,6 +77,7 @@ def edit(id):
         'sd_product_id': data.get('sd_product_id'),
         'query': data.get('query'),
         'is_enabled': data.get('is_enabled'),
+        'product_type': data.get('product_type', 'wire')
     }
 
     validation = validate_product(updates)

--- a/newsroom/push.py
+++ b/newsroom/push.py
@@ -275,6 +275,7 @@ def set_agenda_metadata_from_event(agenda, event):
     agenda['place'] = event.get('place')
     agenda['subject'] = event.get('subject')
     agenda['anpa_category'] = event.get('anpa_category')
+    agenda['products'] = event.get('products')
 
     agenda['event'] = event
 
@@ -299,6 +300,7 @@ def set_agenda_metadata_from_planning(agenda, planning_item):
     agenda['genre'] = planning_item.get('genre')
     agenda['priority'] = planning_item.get('priority')
     agenda['urgency'] = planning_item.get('urgency')
+    agenda['products'] = planning_item.get('products')
 
 
 def set_agenda_planning_items(agenda, planning_item, action='add'):

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -46,7 +46,8 @@ def get_view_data():
         'company': str(user['company']) if user and user.get('company') else None,
         'topics': [t for t in topics if t.get('topic_type') != 'agenda'],
         'formats': [{'format': f['format'], 'name': f['name']} for f in app.download_formatters.values()],
-        'navigations': get_navigations_by_company(str(user['company']) if user and user.get('company') else None),
+        'navigations': get_navigations_by_company(str(user['company']) if user and user.get('company') else None,
+                                                  product_type='wire'),
     }
 
 


### PR DESCRIPTION
- Navigation tabs will use corresponding products for wire and agenda to create navigation buttons
- This PR doesn't include the filtering by products on agenda landing yet (to have as much data as possible initially)