### PR TITLE
fix(wire): fix copy action not working in firefox

### DIFF
--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -2558,3 +2558,9 @@ article.list {
     border-color: none !important;
 }
 // End Wire BEM classes
+
+#copy-area {
+    position: absolute;
+    top: 0;
+    left: -1000px;
+}

--- a/assets/wire/actions.js
+++ b/assets/wire/actions.js
@@ -2,7 +2,7 @@
 import { get, isEmpty } from 'lodash';
 import server from 'server';
 import analytics from 'analytics';
-import { gettext, notify, updateRouteParams, getTimezoneOffset } from 'utils';
+import { gettext, notify, updateRouteParams, getTimezoneOffset, getTextFromHtml } from 'utils';
 import { markItemAsRead, toggleNewsOnlyParam } from './utils';
 import { renderModal, closeModal } from 'actions';
 
@@ -26,11 +26,10 @@ export function preview(item) {
     return {type: PREVIEW_ITEM, item};
 }
 
-
 export function previewAndCopy(item) {
     return (dispatch) => {
         dispatch(previewItem(item));
-        window.setTimeout(() => dispatch(copyPreviewContents(item)), 200);
+        dispatch(copyPreviewContents(item));
     };
 }
 
@@ -103,19 +102,22 @@ export function toggleNews() {
  */
 export function copyPreviewContents(item) {
     return (dispatch, getState) => {
-        const preview = document.getElementById('preview-article');
-        const selection = window.getSelection();
-        const range = document.createRange();
-        selection.removeAllRanges();
-        range.selectNode(preview);
-        selection.addRange(range);
+        const textarea = document.getElementById('copy-area');
+
+        textarea.value = [
+            get(item, 'headline', get(item, 'slugline')),
+            '',
+            get(item, 'body_text') || getTextFromHtml(get(item, 'body_html'))
+        ].join('\n');
+        textarea.select();
+
         if (document.execCommand('copy')) {
             notify.success(gettext('Item copied successfully.'));
             item && analytics.itemEvent('copy', item);
         } else {
             notify.error(gettext('Sorry, Copy is not supported.'));
         }
-        selection.removeAllRanges();
+
         if (getState().user) {
             server.post(`/wire/${item._id}/copy`)
                 .then(dispatch(setCopyItem(item._id)))

--- a/newsroom/templates/layout.html
+++ b/newsroom/templates/layout.html
@@ -132,5 +132,7 @@
 </script>
 {% endif %}
 
+<textarea id="copy-area"></textarea>
+
 </body>
 </html>


### PR DESCRIPTION
it wouldn't work with settimeout in firefox, and the formatting
was broken anyhow so added hidden textarea where we put headline + body
and copy that.

SDAN-284