### PR TITLE
Fix for the coverage status

### DIFF
--- a/assets/agenda/components/AgendaCoverages.jsx
+++ b/assets/agenda/components/AgendaCoverages.jsx
@@ -29,7 +29,7 @@ export default function AgendaCoverages({coverages}) {
                 {coverage.coverage_provider && <span className='coverage-item__text-label mr-1'>{gettext('Source')}:</span>}
                 {coverage.coverage_provider && <span className='mr-2'>{coverage.coverage_provider}</span>}
                 {coverage.coverage_status && <span className='coverage-item__text-label mr-1'>{gettext('Status')}:</span>}
-                {coverage.coverage_status && <span>{coverage.news_coverage_status}</span>}
+                {coverage.coverage_status && <span>{coverage.coverage_status}</span>}
             </div>
         </div>
     ));

--- a/newsroom/push.py
+++ b/newsroom/push.py
@@ -340,7 +340,7 @@ def get_coverages(planning_items):
                 'scheduled': coverage['planning']['scheduled'],
                 'coverage_type': coverage['planning']['g2_content_type'],
                 'workflow_status': coverage['workflow_status'],
-                'news_coverage_status': coverage.get('news_coverage_status', {}).get('label'),
+                'coverage_status': coverage.get('news_coverage_status', {}).get('label'),
                 'coverage_provider': coverage['planning'].get('coverage_provider'),
             })
 


### PR DESCRIPTION
In agenda mappings `coverage_status` field was created but in ingest  `news_coverage_status` was used