### PR TITLE
Added a calendar view option for date navigation

### DIFF
--- a/assets/agenda/components/AgendaApp.jsx
+++ b/assets/agenda/components/AgendaApp.jsx
@@ -204,6 +204,7 @@ class AgendaApp extends React.Component {
                             selectDate={this.props.selectDate}
                             activeDate={this.props.activeDate}
                             activeGrouping={this.props.activeGrouping}
+                            displayCalendar={true}
                         />
 
                         <AgendaListViewControls

--- a/assets/agenda/components/AgendaCalendarButton.jsx
+++ b/assets/agenda/components/AgendaCalendarButton.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {gettext} from 'utils';
+import DatePicker from 'react-datepicker';
+import moment from 'moment';
+
+import 'react-datepicker/dist/react-datepicker.css';
+
+class AgendaCalendarButtonWrapper extends React.Component {
+    render() {
+        return (
+            <button
+                className='btn btn-outline-primary btn-sm mr-3'
+                onClick={this.props.onClick}
+            >
+                {this.props.value}
+            </button>
+        );
+    }
+}
+
+AgendaCalendarButtonWrapper.propTypes = {
+    onClick: PropTypes.func,
+    value: PropTypes.string,
+};
+
+
+
+class AgendaCalendarButton extends React.Component {
+    constructor (props) {
+        super(props);
+
+        this.state = { startDate: moment() };
+        this.handleChange = this.handleChange.bind(this);
+    }
+
+    handleChange(date) {
+        this.props.selectDate(date.valueOf(), 'day');
+        this.setState({ startDate: date });
+    }
+
+    render() {
+        return (<DatePicker
+            customInput={<AgendaCalendarButtonWrapper />}
+            dateFormat='dddd, D MMMM'
+            todayButton={gettext('Today')}
+            selected={this.state.startDate}
+            onChange={this.handleChange}
+            popperModifiers={{
+                offset: {
+                    enabled: true,
+                    offset: '5px, 10px'
+                },
+                preventOverflow: {
+                    enabled: true,
+                    escapeWithReference: false, // force popper to stay in viewport (even when input is scrolled out of view)
+                    boundariesElement: 'viewport'
+                }
+            }}
+        />);
+    }
+}
+
+
+AgendaCalendarButton.propTypes = {
+    selectDate: PropTypes.func,
+};
+
+export default AgendaCalendarButton;

--- a/assets/agenda/components/AgendaDateButtons.jsx
+++ b/assets/agenda/components/AgendaDateButtons.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import {gettext} from 'utils';
+import {formatNavigationDate, getNext, getPrevious} from '../utils';
+
+
+function AgendaDateButtons({selectDate, activeDate, activeGrouping}) {
+    return ([<span className='mr-3' key='label'>{formatNavigationDate(activeDate, activeGrouping)}</span>,
+        <button
+            key='today'
+            type='button'
+            className='btn btn-outline-primary btn-sm mr-3'
+            onClick={() => selectDate(Date.now(), 'day')}>
+            {gettext('Today')}
+        </button>,
+        <button
+            key='left'
+            type='button'
+            className='icon-button icon-button--small mr-2'
+            onClick={() => selectDate(getPrevious(activeDate, activeGrouping), activeGrouping)}>
+            <i className='icon--arrow-right icon--rotate-180'></i>
+        </button>,
+        <button
+            key='right'
+            type='button'
+            className='icon-button icon-button--small mr-3'
+            onClick={() => selectDate(getNext(activeDate, activeGrouping), activeGrouping)}>
+            <i className='icon--arrow-right'></i>
+        </button>,
+        <button
+            key='D'
+            type='button'
+            className={classnames('btn btn-outline-primary btn-sm mr-2', {'active': activeGrouping === 'day'})}
+            onClick={() => selectDate(activeDate, 'day')}>
+            {gettext('D')}
+        </button>,
+        <button
+            key='W'
+            type='button'
+            className={classnames('btn btn-outline-primary btn-sm mr-2', {'active': activeGrouping === 'week'})}
+            onClick={() => selectDate(activeDate, 'week')}>
+            {gettext('W')}
+        </button>,
+        <button
+            key='M'
+            type='button'
+            className={classnames('btn btn-outline-primary btn-sm', {'active': activeGrouping === 'month'})}
+            onClick={() => selectDate(activeDate, 'month')}>
+            {gettext('M')}
+        </button>]);
+}
+
+AgendaDateButtons.propTypes = {
+    selectDate: PropTypes.func,
+    activeDate: PropTypes.number,
+    activeGrouping: PropTypes.string,
+};
+
+export default AgendaDateButtons;

--- a/assets/agenda/components/AgendaDateNavigation.jsx
+++ b/assets/agenda/components/AgendaDateNavigation.jsx
@@ -1,49 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
-import {gettext} from 'utils';
-import {formatNavigationDate, getPrevious, getNext} from 'agenda/utils';
+import AgendaDateButtons from './AgendaDateButtons';
+import AgendaCalendarButton from './AgendaCalendarButton';
 
 
-function AgendaDateNavigation({selectDate, activeDate, activeGrouping}) {
+function AgendaDateNavigation({selectDate, activeDate, activeGrouping, displayCalendar}) {
     return (<div className='d-none d-lg-flex align-items-center mr-3'>
-        <span className='mr-3'>{formatNavigationDate(activeDate, activeGrouping)}</span>
-        <button
-            type='button'
-            className='btn btn-outline-primary btn-sm mr-3'
-            onClick={() => selectDate(Date.now(), 'day')}>
-            {gettext('Today')}
-        </button>
-        <button
-            type='button'
-            className='icon-button icon-button--small mr-2'
-            onClick={() => selectDate(getPrevious(activeDate, activeGrouping), activeGrouping)}>
-            <i className='icon--arrow-right icon--rotate-180'></i>
-        </button>
-        <button
-            type='button'
-            className='icon-button icon-button--small mr-3'
-            onClick={() => selectDate(getNext(activeDate, activeGrouping), activeGrouping)}>
-            <i className='icon--arrow-right'></i>
-        </button>
-        <button
-            type='button'
-            className={classnames('btn btn-outline-primary btn-sm mr-2', {'active': activeGrouping === 'day'})}
-            onClick={() => selectDate(activeDate, 'day')}>
-            {gettext('D')}
-        </button>
-        <button
-            type='button'
-            className={classnames('btn btn-outline-primary btn-sm mr-2', {'active': activeGrouping === 'week'})}
-            onClick={() => selectDate(activeDate, 'week')}>
-            {gettext('W')}
-        </button>
-        <button
-            type='button'
-            className={classnames('btn btn-outline-primary btn-sm', {'active': activeGrouping === 'month'})}
-            onClick={() => selectDate(activeDate, 'month')}>
-            {gettext('M')}
-        </button>
+        {displayCalendar && <AgendaCalendarButton selectDate={selectDate}/>}
+
+        {!displayCalendar && <AgendaDateButtons
+            selectDate={selectDate} activeDate={activeDate} activeGrouping={activeGrouping}/>}
     </div>);
 }
 
@@ -51,6 +17,7 @@ AgendaDateNavigation.propTypes = {
     selectDate: PropTypes.func,
     activeDate: PropTypes.number,
     activeGrouping: PropTypes.string,
+    displayCalendar: PropTypes.bool,
 };
 
 export default AgendaDateNavigation;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "node-sass": "^4.5.3",
     "popper.js": "^1.11.0",
     "react": "^16.0.0",
+    "react-datepicker": "^1.5.0",
     "react-dom": "^16.0.0",
     "react-redux": "^5.0.6",
     "react-toggle": "^4.0.2",


### PR DESCRIPTION
- AAP suggested to replace date navigations with a date picker. 
- So keeping the old navigation buttons (which we can then configure as an option)
- Used [react-datepicker](https://www.npmjs.com/package/react-datepicker) for basic implemetation