### PR TITLE
[SDAN-304] - Missing coverage icons

### DIFF
--- a/assets/agenda/components/AgendaCoverages.jsx
+++ b/assets/agenda/components/AgendaCoverages.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
 import { gettext, formatCoverageDate } from 'utils';
 import CoverageItemStatus from './CoverageItemStatus';
+import {getCoverageDisplayName, getCoverageIcon} from '../utils';
 
 const getCoverageStatusClass = (coverage) =>
     coverage.workflow_status === 'active' ? 'icon--green' : 'icon--gray-light';
@@ -16,8 +17,8 @@ export default function AgendaCoverages({coverages}) {
         <div className='coverage-item' key={coverage.coverage_id}>
             <div className='coverage-item__row'>
                 <span className='d-flex coverage-item--element-grow text-overflow-ellipsis'>
-                    <i className={`icon-small--coverage-${coverage.coverage_type} ${getCoverageStatusClass(coverage)} mr-2`}></i>
-                    <span className='text-overflow-ellipsis'>{coverage.coverage_type}</span>
+                    <i className={`icon-small--coverage-${getCoverageIcon(coverage.coverage_type)} ${getCoverageStatusClass(coverage)} mr-2`}></i>
+                    <span className='text-overflow-ellipsis'>{getCoverageDisplayName(coverage.coverage_type)}</span>
                 </span>
                 <span className='d-flex'>
                     <i className='icon-small--clock icon--gray mr-1'></i>

--- a/assets/agenda/components/AgendaListItemIcons.jsx
+++ b/assets/agenda/components/AgendaListItemIcons.jsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {bem} from 'ui/utils';
-import {hasCoverages, isCoverageBetweenEventDates, isCoverageForExtraDay, hasLocation, getLocationString} from '../utils';
+import {
+    hasCoverages,
+    isCoverageBetweenEventDates,
+    isCoverageForExtraDay,
+    hasLocation,
+    getLocationString,
+    getCoverageIcon
+} from '../utils';
 import AgendaListItemLabels from './AgendaListItemLabels';
 import MetaTime from './MetaTime';
 import {gettext, formatDate, formatTime} from 'utils';
@@ -18,7 +25,7 @@ function AgendaListItemIcons({item, group, hideCoverages, row}) {
             {hasCoverages(item) && !hideCoverages &&
                 <div className='wire-articles__item__icons wire-articles__item__icons--dashed-border align-self-start'>
                     {item.coverages.map((coverage) => {
-                        const coverageClass = `icon--coverage-${coverage.coverage_type}`;
+                        const coverageClass = `icon--coverage-${getCoverageIcon(coverage.coverage_type)}`;
                         const statusClass = coverage.workflow_status === 'active' ? 'icon--green' : 'icon--gray-light';
                         return (!group || (isCoverageBetweenEventDates(item, coverage) || isCoverageForExtraDay(coverage, group)) &&
                           <span

--- a/assets/agenda/utils.js
+++ b/assets/agenda/utils.js
@@ -1,6 +1,6 @@
 import { get, isEmpty, includes } from 'lodash';
 import moment from 'moment/moment';
-import {formatDate, formatMonth, formatWeek} from '../utils';
+import {formatDate, formatMonth, formatWeek, getConfig} from '../utils';
 
 const STATUS_KILLED = 'killed';
 const STATUS_CANCELED = 'cancelled';
@@ -76,6 +76,28 @@ export function isRescheduled(item) {
  */
 export function hasCoverages(item) {
     return !isEmpty(get(item, 'coverages'));
+}
+
+/**
+ * Returns icon name of the given coverage type
+ *
+ * @param coverageType
+ * @returns {*}
+ */
+export function getCoverageIcon(coverageType) {
+    const coverageTypes = getConfig('coverage_types', {}, 'agendaData');
+    return get(coverageTypes, `${coverageType}.icon`, 'unrecognized');
+}
+
+/**
+ * Returns display name of the given coverage type
+ *
+ * @param coverageType
+ * @returns {*}
+ */
+export function getCoverageDisplayName(coverageType) {
+    const coverageTypes = getConfig('coverage_types', {}, 'agendaData');
+    return get(coverageTypes, `${coverageType}.name`, coverageType);
 }
 
 /**

--- a/assets/utils.js
+++ b/assets/utils.js
@@ -375,10 +375,11 @@ export function errorHandler(error, dispatch, setError) {
  *
  * @param {String} key
  * @param {Mixed} defaultValue
+ * @param {String} namespace
  * @return {Mixed}
  */
-export function getConfig(key, defaultValue) {
-    return get(window.newsroom, key, defaultValue);
+export function getConfig(key, defaultValue, namespace='newsroom') {
+    return get(window[namespace], key, defaultValue);
 }
 
 export function getTimezoneOffset() {

--- a/newsroom/agenda/views.py
+++ b/newsroom/agenda/views.py
@@ -67,6 +67,7 @@ def get_view_data():
         'navigations': get_navigations_by_company(str(user['company']) if user and user.get('company') else None,
                                                   product_type='agenda'),
         'saved_items': get_resource_service('agenda').get_saved_items_count(),
+        'coverage_types': app.config['COVERAGE_TYPES'],
     }
 
 

--- a/newsroom/default_settings.py
+++ b/newsroom/default_settings.py
@@ -213,3 +213,13 @@ DISPLAY_ABSTRACT = False
 WATERMARK_IMAGE = os.path.join(os.path.dirname(__file__), 'static', 'watermark.png')
 
 GOOGLE_MAPS_KEY = os.environ.get('GOOGLE_MAPS_KEY')
+
+COVERAGE_TYPES = {
+    'text': {'name': 'Text', 'icon': 'text'},
+    'photo': {'name': 'Photo', 'icon': 'photo'},
+    'video': {'name': 'Video', 'icon': 'video'},
+    'explainer': {'name': 'Explainer', 'icon': 'explainer'},
+    'infographics': {'name': 'Infographics', 'icon': 'infographics'},
+    'live_video': {'name': 'Live Video', 'icon': 'live-video'},
+    'live_blog': {'name': 'Live Blog', 'icon': 'live-blog'}
+}


### PR DESCRIPTION
- Passing coverage types to client from `default_settings` to keep it more generic