### PR TITLE
[SDAN-311] - Cancelled planning item

### DIFF
--- a/newsroom/push.py
+++ b/newsroom/push.py
@@ -257,6 +257,8 @@ def init_adhoc_agenda(planning):
         'end': planning['planning_date'],
     }
 
+    agenda['state'] = planning['state']
+
     return agenda
 
 


### PR DESCRIPTION
- If the planning item is an `ad-hoc` item (where there's no event) state was not saved