### PR TITLE
Existing items were not auto updating

### DIFF
--- a/assets/agenda/actions.js
+++ b/assets/agenda/actions.js
@@ -337,7 +337,10 @@ export function pushNotification(push) {
             return dispatch(setNewItemsByTopic(push.extra));
 
         case 'new_item':
-            return dispatch(setNewItems(push.extra));
+            return new Promise((resolve, reject) => {
+                dispatch(updateItems(push.extra));
+                dispatch(fetchNewItems()).then(resolve).catch(reject);
+            });
 
         case `topics:${user}`:
             return dispatch(reloadTopics(user));
@@ -367,6 +370,11 @@ function setTopics(topics) {
 export const SET_NEW_ITEMS = 'SET_NEW_ITEMS';
 export function setNewItems(data) {
     return {type: SET_NEW_ITEMS, data};
+}
+
+export const UPDATE_ITEMS = 'UPDATE_ITEMS';
+export function updateItems(data) {
+    return {type: UPDATE_ITEMS, data};
 }
 
 export function fetchNewItems() {

--- a/assets/agenda/reducers.js
+++ b/assets/agenda/reducers.js
@@ -5,6 +5,7 @@ import {
     SELECT_DATE,
     WATCH_EVENTS,
     STOP_WATCHING_EVENTS,
+    UPDATE_ITEMS,
 } from './actions';
 
 import { get, isEmpty } from 'lodash';
@@ -123,6 +124,20 @@ export default function agendaReducer(state = initialState, action) {
         });
 
         return {...state, itemsById};
+    }
+
+    case UPDATE_ITEMS: {
+        const itemsById = Object.assign({}, state.itemsById);
+        get(action.data, '_items', []).map(item => {
+            if(itemsById[item._id]) {
+                itemsById[item._id] = item;
+            }
+        });
+
+        return {
+            ...state,
+            itemsById,
+        };
     }
 
     case INIT_DATA: {

--- a/assets/reducers.js
+++ b/assets/reducers.js
@@ -73,14 +73,6 @@ function updateItemActions(state, items, action) {
     return itemsById;
 }
 
-function setNewItemsById(state, action) {
-    let itemsById = state.itemsById;
-    if (get(action.data, 'item._id') && state.itemsById[action.data.item._id]) {
-        itemsById = Object.assign({}, itemsById);
-        itemsById[action.data.item._id] = action.data.item;
-    }
-    return itemsById;
-}
 
 
 export function defaultReducer(state, action) {
@@ -276,7 +268,11 @@ export function defaultReducer(state, action) {
             newItemsByTopic[topic] = previous.concat([action.data.item]);
         });
 
-        const itemsById = setNewItemsById(state, action);
+        let itemsById = state.itemsById;
+        if (get(action.data, 'item._id') && state.itemsById[action.data.item._id]) {
+            itemsById = Object.assign({}, itemsById);
+            itemsById[action.data.item._id] = action.data.item;
+        }
 
         return {
             ...state,
@@ -297,10 +293,8 @@ export function defaultReducer(state, action) {
     case SET_NEW_ITEMS: {
         const newItems = action.data._items.filter((item) => !item.nextversion && !state.itemsById[item._id]).map((item) => item._id);
         const newItemsData = action.data;
-        const itemsById = setNewItemsById(state, action);
         return {
             ...state,
-            itemsById,
             newItems,
             newItemsData,
         };


### PR DESCRIPTION
- Seperated update and set_new_items for agenda
- Update item will update the existing item without fetching from server
- Handling of new items will work identical for agenda and wire:
  - Results are fetched from server
  - If there are new items then we display the refresh button