### PR TITLE
[SDAN-358] Update cores to update redis dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
     'flask_pymongo>=0.5.2,<1.0',
     'honcho>=1.0.1',
     'gunicorn>=19.7.1',
-    'superdesk-core>=1.24,<1.25',
+    'superdesk-core>=1.26,<1.27',
     'icalendar>=4.0.3,<4.1',
 ]
 


### PR DESCRIPTION
Redis==3.0.0 breaks compatibility with Celery. https://github.com/celery/celery/issues/5175

Superdesk Core 1.26 was modified to use Redis==2.10.6