### PR TITLE
(fix) Fixing Permission tab for Companies and Navigations.

### DIFF
--- a/assets/companies/components/CompanyPermissions.jsx
+++ b/assets/companies/components/CompanyPermissions.jsx
@@ -90,7 +90,7 @@ class CompanyPermissions extends React.Component {
                             {this.props['sections'].map((section) => (
                                 [<label key={`${section.id}label`}>{gettext('Products')} {`(${section.name})`}</label>,
                                     <ul key={`${section.id}product`} className="list-unstyled">
-                                        {this.props['products'].filter((p) => (p.product_type || 'wire').toLowerCase() === section.name.toLowerCase())
+                                        {this.props['products'].filter((p) => (p.product_type || 'wire').toLowerCase() === section._id.toLowerCase())
                                             .map((product) => (
                                                 <li key={product._id}>
                                                     <CheckboxInput

--- a/assets/navigations/components/EditNavigation.jsx
+++ b/assets/navigations/components/EditNavigation.jsx
@@ -40,6 +40,9 @@ class EditNavigation extends React.Component {
 
     render() {
         const tile_images = get(this.props, 'navigation.tile_images') || [];
+        const getActiveSection = () => this.props.sections.filter(
+            s => s._id === get(this.props.navigation, 'product_type')
+        );
 
         return (
             <div className='list-item__preview'>
@@ -129,7 +132,7 @@ class EditNavigation extends React.Component {
                             items={this.props.products}
                             field="products"
                             onSave={this.props.saveProducts}
-                            groups={this.props.sections}
+                            groups={getActiveSection()}
                             groupField={'product_type'}
                             groupDefaultValue={'wire'}
                         />

--- a/assets/navigations/components/Navigations.jsx
+++ b/assets/navigations/components/Navigations.jsx
@@ -62,7 +62,6 @@ class Navigations extends React.Component {
     render() {
         const progressStyle = {width: '25%'};
         const sectionFilter = (navigation) => !this.props.activeSection || get(navigation, 'product_type', 'wire') === this.props.activeSection;
-        const getActiveSection = () => this.props.sections.filter(s => s._id === this.props.activeSection);
 
         return (
             <div className="flex-row">
@@ -96,7 +95,7 @@ class Navigations extends React.Component {
                         products={this.props.products}
                         saveProducts={this.props.saveProducts}
                         fetchProducts={this.props.fetchProducts}
-                        sections={getActiveSection()}
+                        sections={this.props.sections}
                     />
                 }
             </div>


### PR DESCRIPTION
Fixes following issues:
- Products for market place and am news were not displayed on the companies permission tab
- Permission tab was displaying the products of different section if the user changes the section.
