### PR TITLE
[SDAN-377][SDAN-378] Handling of  multiple linked planning items.

### DIFF
--- a/assets/agenda/actions.js
+++ b/assets/agenda/actions.js
@@ -39,29 +39,29 @@ export function setActive(item) {
     return {type: SET_ACTIVE, item};
 }
 
+
 export const PREVIEW_ITEM = 'PREVIEW_ITEM';
-export function preview(item, group) {
-    return {type: PREVIEW_ITEM, item, group};
+export function preview(item, group, plan) {
+    return {type: PREVIEW_ITEM, item, group, plan};
 }
 
 export function previewAndCopy(item) {
     return (dispatch) => {
-        dispatch(previewItem(item));
         dispatch(copyPreviewContents(item));
     };
 }
 
-export function previewItem(item, group) {
+export function previewItem(item, group, plan) {
     return (dispatch, getState) => {
         markItemAsRead(item, getState());
-        dispatch(preview(item, group));
+        dispatch(preview(item, group, plan));
         item && analytics.itemEvent('preview', item);
     };
 }
 
 export const OPEN_ITEM = 'OPEN_ITEM';
-export function openItemDetails(item, group) {
-    return {type: OPEN_ITEM, item, group};
+export function openItemDetails(item, group, plan) {
+    return {type: OPEN_ITEM, item, group, plan};
 }
 
 export function requestCoverage(item, message) {
@@ -74,12 +74,14 @@ export function requestCoverage(item, message) {
     };
 }
 
-export function openItem(item, group) {
+export function openItem(item, group, plan) {
     return (dispatch, getState) => {
         markItemAsRead(item, getState());
-        dispatch(openItemDetails(item, group));
+        dispatch(openItemDetails(item, group, plan));
         updateRouteParams({
-            item: item ? item._id : null
+            item: item ? item._id : null,
+            group: group || null,
+            plan: get(plan, 'guid', null),
         }, getState());
         item && analytics.itemEvent('open', item);
         analytics.itemView(item);
@@ -562,7 +564,9 @@ export function initParams(params) {
             dispatch(fetchItem(params.get('item')))
                 .then(() => {
                     const item = getState().itemsById[params.get('item')];
-                    dispatch(openItem(item));
+                    const plan = (get(item, 'planning_items') || []).find((p) => p.guid === params.get('plan'));
+
+                    dispatch(openItem(item, params.get('group'), plan || {}));
                 });
         }
     };

--- a/assets/agenda/components/AgendaApp.jsx
+++ b/assets/agenda/components/AgendaApp.jsx
@@ -67,7 +67,8 @@ class AgendaApp extends BaseApp {
             'wire-articles__two-side-panes': panesCount === 2,
         });
 
-        const onDetailClose = this.props.detail ? null : () => this.props.actions.filter(a => a.id == 'open')[0].action(null);
+        const onDetailClose = this.props.detail ? null :
+            () => this.props.actions.filter(a => a.id == 'open')[0].action(null, this.props.previewGroup, this.props.previewPlan);
 
         const groups = [
             {
@@ -96,6 +97,7 @@ class AgendaApp extends BaseApp {
                 onClose={onDetailClose}
                 requestCoverage={this.props.requestCoverage}
                 group={this.props.previewGroup}
+                plan={this.props.previewPlan}
             />] : [
                 <section key="contentHeader" className='content-header'>
                     <SelectedItemsBar
@@ -169,6 +171,7 @@ class AgendaApp extends BaseApp {
                                 activeNavigation={this.props.activeNavigation}
                                 newsOnly={this.props.newsOnly}
                                 scrollClass={this.state.scrollClass}
+                                hideTotalItems={false}
                             />
 
                             <AgendaList
@@ -185,6 +188,7 @@ class AgendaApp extends BaseApp {
                             openItemDetails={this.props.openItemDetails}
                             requestCoverage={this.props.requestCoverage}
                             previewGroup={this.props.previewGroup}
+                            previewPlan={this.props.previewPlan}
                         />
                     </div>
                 </section>
@@ -194,8 +198,7 @@ class AgendaApp extends BaseApp {
                     this.props.navigations,
                     this.props.activeNavigation,
                     this.props.activeTopic
-                ),
-                this.renderSavedItemsCount()
+                )
             ])
         );
     }
@@ -210,6 +213,7 @@ AgendaApp.propTypes = {
     createdFilter: PropTypes.object,
     itemToPreview: PropTypes.object,
     previewGroup: PropTypes.string,
+    previewPlan: PropTypes.object,
     itemToOpen: PropTypes.object,
     itemsById: PropTypes.object,
     modal: PropTypes.object,
@@ -252,6 +256,7 @@ const mapStateToProps = (state) => ({
     createdFilter: get(state, 'search.createdFilter'),
     itemToPreview: state.previewItem ? state.itemsById[state.previewItem] : null,
     previewGroup: state.previewGroup,
+    previewPlan: state.previewPlan,
     itemToOpen: state.openItem ? state.itemsById[state.openItem._id] : null,
     itemsById: state.itemsById,
     modal: state.modal,

--- a/assets/agenda/components/AgendaCoverages.jsx
+++ b/assets/agenda/components/AgendaCoverages.jsx
@@ -7,14 +7,14 @@ import {getCoverageDisplayName, getCoverageIcon, WORKFLOW_COLORS, getInternalNot
 import AgendaInternalNote from './AgendaInternalNote';
 
 
-export default function AgendaCoverages({item}) {
-    if (isEmpty(item.coverages)) {
+export default function AgendaCoverages({item, coverages}) {
+    if (isEmpty(coverages)) {
         return null;
     }
 
     const internalNotes = getInternalNotesFromCoverages(item);
 
-    return item.coverages.map((coverage) => (
+    return coverages.map((coverage) => (
         <div className='coverage-item' key={coverage.coverage_id}>
             <div className='coverage-item__row'>
                 <span className='d-flex coverage-item--element-grow text-overflow-ellipsis'>
@@ -35,12 +35,13 @@ export default function AgendaCoverages({item}) {
             </div>
 
             {!isEmpty(internalNotes) && internalNotes[coverage.coverage_id] && <div className='coverage-item__row'>
-                <AgendaInternalNote internalNotes={[internalNotes[coverage.coverage_id]]} />
+                <AgendaInternalNote internalNote={internalNotes[coverage.coverage_id]} />
             </div>}
         </div>
     ));
 }
 
 AgendaCoverages.propTypes = {
-    item: PropTypes.object
+    item: PropTypes.object,
+    coverages: PropTypes.arrayOf(PropTypes.object),
 };

--- a/assets/agenda/components/AgendaEdNote.jsx
+++ b/assets/agenda/components/AgendaEdNote.jsx
@@ -1,19 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default function AgendaEdNote({item}) {
-    if (!item.ednote) {
+export default function AgendaEdNote({item, plan}) {
+    if (!item.ednote && !plan.ednote) {
         return null;
     }
 
     return (
         <div className="wire-column__preview__editorial-note">
             <i className="icon-small--info icon--gray" />
-            <span>{item.ednote}</span>
+            <span>{plan.ednote || item.ednote}</span>
         </div>
     );
 }
 
 AgendaEdNote.propTypes = {
     item: PropTypes.object.isRequired,
+    plan: PropTypes.object,
 };

--- a/assets/agenda/components/AgendaInternalNote.jsx
+++ b/assets/agenda/components/AgendaInternalNote.jsx
@@ -1,20 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default function AgendaInternalNote({internalNotes}) {
+export default function AgendaInternalNote({internalNote}) {
 
-    if (!internalNotes || !internalNotes.length) {
+    if (!internalNote) {
         return null;
     }
 
     return (
-        internalNotes.map((note, index) => (<div key={index} className="wire-column__preview__internal-note">
+        <div className="wire-column__preview__internal-note">
             <i className="icon-small--info icon--gray" />
-            <span >{note}</span>
-        </div>))
+            <span >{internalNote}</span>
+        </div>
     );
 }
 
 AgendaInternalNote.propTypes = {
-    internalNotes: PropTypes.array,
+    internalNote: PropTypes.string,
 };

--- a/assets/agenda/components/AgendaItemDetails.jsx
+++ b/assets/agenda/components/AgendaItemDetails.jsx
@@ -18,18 +18,23 @@ import ArticleBody from 'ui/components/ArticleBody';
 import ArticleSidebar from 'ui/components/ArticleSidebar';
 import ArticleSidebarBox from 'ui/components/ArticleSidebarBox';
 
-import {hasCoverages, hasAttachments, getInternalNotes} from '../utils';
+import {
+    hasCoverages,
+    hasAttachments,
+    getInternalNote,
+    getCoveragesForDisplay,
+} from '../utils';
 
 import AgendaLongDescription from './AgendaLongDescription';
 import AgendaMeta from './AgendaMeta';
 import AgendaEdNote from './AgendaEdNote';
 import AgendaInternalNote from './AgendaInternalNote';
-import AgendaCoverages from './AgendaCoverages';
+import AgendaPreviewCoverages from './AgendaPreviewCoverages';
 import AgendaAttachments from './AgendaAttachments';
 import AgendaCoverageRequest from './AgendaCoverageRequest';
 import AgendaTags from './AgendaTags';
 
-export default function AgendaItemDetails({item, user, actions, onClose, requestCoverage, group}) {
+export default function AgendaItemDetails({item, user, actions, onClose, requestCoverage, group, plan}) {
     const locations = getLocations(item);
     let map = null;
 
@@ -43,6 +48,8 @@ export default function AgendaItemDetails({item, user, actions, onClose, request
         map = <StaticMap locations={locations} scale={2} />;
     }
 
+    const displayCoverages = getCoveragesForDisplay(item, plan, group);
+
     return (
         <Content type="item-detail">
             <ContentHeader>
@@ -54,21 +61,25 @@ export default function AgendaItemDetails({item, user, actions, onClose, request
             <Article image={map} item={item} group={group}>
                 <ArticleBody>
                     <AgendaMeta item={item} />
-                    <AgendaLongDescription item={item} />
+                    <AgendaLongDescription item={item} plan={plan || {}}/>
                 </ArticleBody>
                 <ArticleSidebar>
-                    <ArticleSidebarBox label={gettext('Coverages')}>
-                        {hasCoverages(item) && <AgendaCoverages item={item} />}
+                    <div>
+                        {hasCoverages(item) &&
+                        <AgendaPreviewCoverages
+                            item={item}
+                            currentCoverage={displayCoverages.current}
+                            previousCoverage={displayCoverages.previous} />}
                         <AgendaCoverageRequest item={item} requestCoverage={requestCoverage}/>
-                    </ArticleSidebarBox>
+                    </div>
                     {hasAttachments(item) && (
                         <ArticleSidebarBox label={gettext('Attachments')}>
                             <AgendaAttachments item={item} />
                         </ArticleSidebarBox>
                     )}
-                    <AgendaTags item={item} isItemDetail={true} />
-                    <AgendaEdNote item={item} />
-                    <AgendaInternalNote internalNotes={getInternalNotes(item)} />
+                    <AgendaTags item={item} plan={plan || {}} isItemDetail={true} />
+                    <AgendaEdNote item={item} plan={plan || {}}/>
+                    <AgendaInternalNote internalNotes={getInternalNote(item, plan || {})} />
                 </ArticleSidebar>
             </Article>
         </Content>
@@ -86,4 +97,5 @@ AgendaItemDetails.propTypes = {
     onClose: PropTypes.func,
     requestCoverage: PropTypes.func,
     group: PropTypes.string,
+    plan: PropTypes.object,
 };

--- a/assets/agenda/components/AgendaItemDetails.jsx
+++ b/assets/agenda/components/AgendaItemDetails.jsx
@@ -69,7 +69,7 @@ export default function AgendaItemDetails({item, user, actions, onClose, request
                         <AgendaPreviewCoverages
                             item={item}
                             currentCoverage={displayCoverages.current}
-                            previousCoverage={displayCoverages.previous} />}
+                            previousCoverage={displayCoverages.previous}/>}
                         <AgendaCoverageRequest item={item} requestCoverage={requestCoverage}/>
                     </div>
                     {hasAttachments(item) && (

--- a/assets/agenda/components/AgendaList.jsx
+++ b/assets/agenda/components/AgendaList.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Fragment} from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
@@ -10,7 +10,7 @@ import AgendaListItem from './AgendaListItem';
 import { setActive, previewItem, toggleSelected, openItem } from '../actions';
 import { EXTENDED_VIEW } from 'wire/defaults';
 import { getIntVersion } from 'wire/utils';
-import { groupItems } from 'agenda/utils';
+import { groupItems, getPlanningItemsByGroup, getListItems } from 'agenda/utils';
 
 
 const PREVIEW_TIMEOUT = 500; // time to preview an item after selecting using kb
@@ -20,10 +20,21 @@ const CLICK_TIMEOUT = 200; // time when we wait for double click after click
 const itemsSelector = (state) => state.items.map((_id) => state.itemsById[_id]);
 const activeDateSelector = (state) => get(state, 'agenda.activeDate');
 const activeGroupingSelector = (state) => get(state, 'agenda.activeGrouping');
+const itemsByIdSelector = (state) => get(state, 'itemsById', {});
 
 const groupedItemsSelector = createSelector(
     [itemsSelector, activeDateSelector, activeGroupingSelector],
     groupItems);
+
+/**
+ * Single event or planning item could be display multiple times.
+ * Hence, the list items needs to tbe calculate so that keyboard scroll works.
+ * This selector calculates list of items.
+ */
+const listItemsSelector = createSelector(
+    [groupedItemsSelector, itemsByIdSelector],
+    getListItems
+);
 
 
 class AgendaList extends React.Component {
@@ -38,6 +49,7 @@ class AgendaList extends React.Component {
         this.onActionList = this.onActionList.bind(this);
         this.filterActions = this.filterActions.bind(this);
         this.resetActioningItem = this.resetActioningItem.bind(this);
+        this.isActiveItem = this.isActiveItem.bind(this);
     }
 
     onKeyDown(event) {
@@ -64,20 +76,34 @@ class AgendaList extends React.Component {
         }
 
         event.preventDefault();
-        const activeIndex = this.props.activeItem ? this.props.items.indexOf(this.props.activeItem) : -1;
+        const activeItem = this.props.activeItem;
+
+        const activeIndex = this.props.activeItem ? this.props.listItems.findIndex((item) => {
+            return item._id === activeItem._id &&
+                item.group === activeItem.group &&
+                get(item, 'plan._id') === get(activeItem, 'plan._id');
+        }) : -1;
 
         // keep it within <0, items.length) interval
-        const nextIndex = Math.max(0, Math.min(activeIndex + diff, this.props.items.length - 1));
-        const nextItemId = this.props.items[nextIndex];
-        const nextItem = this.props.itemsById[nextItemId];
+        const nextIndex = Math.max(0, Math.min(activeIndex + diff, this.props.listItems.length - 1));
+        const nextItemInList = this.props.listItems[nextIndex];
+        const nextItem = this.props.itemsById[nextItemInList._id];
 
-        this.props.dispatch(setActive(nextItemId));
+        this.props.dispatch(setActive(nextItemInList));
 
         if (this.previewTimeout) {
             clearTimeout(this.previewTimeout);
         }
 
-        this.previewTimeout = setTimeout(() => this.props.dispatch(previewItem(nextItem)), PREVIEW_TIMEOUT);
+        this.previewTimeout = setTimeout(() => this.props.dispatch(
+            previewItem(nextItem, nextItemInList.group, nextItemInList.plan)
+        ), PREVIEW_TIMEOUT);
+
+        const activeElements = document.getElementsByClassName('wire-articles__item--open');
+
+        if (activeElements && activeElements.length) {
+            activeElements[0].scrollIntoView({behavior: 'smooth', block: 'center', inline: 'nearest'});
+        }
     }
 
     cancelPreviewTimeout() {
@@ -94,19 +120,21 @@ class AgendaList extends React.Component {
         }
     }
 
-    onItemClick(item, group) {
+    onItemClick(item, group, plan) {
         const itemId = item._id;
         this.setState({actioningItem: null});
         this.cancelPreviewTimeout();
         this.cancelClickTimeout();
 
         this.clickTimeout = setTimeout(() => {
-            this.props.dispatch(setActive(itemId));
+            this.props.dispatch(setActive({_id: itemId, group: group, plan: plan}));
 
-            if (this.props.previewItem !== itemId) {
-                this.props.dispatch(previewItem(item, group));
+            if (this.props.previewItem !== itemId ||
+                this.props.previewGroup !== group ||
+                this.props.previewPlan !== plan) {
+                this.props.dispatch(previewItem(item, group, plan));
             } else {
-                this.props.dispatch(previewItem(null, null));
+                this.props.dispatch(previewItem(null, null, null));
             }
         }, CLICK_TIMEOUT);
     }
@@ -115,23 +143,42 @@ class AgendaList extends React.Component {
         this.setState({actioningItem: null});
     }
 
-    onItemDoubleClick(item, group) {
+    onItemDoubleClick(item, group, plan) {
         this.cancelClickTimeout();
-        this.props.dispatch(setActive(item._id));
-        this.props.dispatch(openItem(item, group));
+        this.props.dispatch(setActive({_id: item._id, group: group, plan: plan}));
+        this.props.dispatch(openItem(item, group, plan));
     }
 
-    onActionList(event, item, group) {
+    onActionList(event, item, group, plan) {
         event.stopPropagation();
-        if (this.state.actioningItem && this.state.actioningItem._id === item._id) {
-            this.setState({actioningItem: null});
+        if (this.state.actioningItem && this.state.actioningItem._id === item._id &&
+            (!this.state.activePlan || (this.state.activePlan && this.state.activePlan.guid === get(plan, 'guid')))) {
+            this.setState({actioningItem: null, activeGroup: null, activePlan: null});
         } else {
-            this.setState({actioningItem: item, activeGroup: group});
+            this.setState({actioningItem: item, activeGroup: group, activePlan: plan});
         }
     }
 
     filterActions(item) {
         return this.props.actions.filter((action) => !action.when || action.when(this.props, item));
+    }
+
+    isActiveItem(_id, group, plan) {
+        const { activeItem } = this.props;
+
+        if (!activeItem || (!_id && !group && !plan)) {
+            return false;
+        }
+
+        if (_id && group && plan) {
+            return _id === activeItem._id && group === activeItem.group && plan.guid === activeItem.plan.guid;
+        }
+
+        if (_id && group) {
+            return _id === activeItem._id && group === activeItem.group;
+        }
+
+        return _id === activeItem._id;
     }
 
     componentDidUpdate(nextProps) {
@@ -142,34 +189,76 @@ class AgendaList extends React.Component {
         }
     }
 
+    componentWillReceiveProps(nextProps) {
+        if (!nextProps.groupedItems) {
+            return;
+        }
+    }
+
     render() {
-        const {items, itemsById, activeItem, activeView, selectedItems, readItems} = this.props;
+        const {items, itemsById, activeView, selectedItems, readItems} = this.props;
         const isExtended = activeView === EXTENDED_VIEW;
-        const articleGroups = Object.keys(this.props.groupedItems).map((keyDate) =>
+        const articleGroups = this.props.groupedItems.map((group) =>
             [
-                <div className='wire-articles__header' key={`${keyDate}header`}>
-                    {keyDate}
+                <div className='wire-articles__header' key={`${group.date}header`}>
+                    {group.date}
                 </div>,
 
-                <div className = 'wire-articles__group' key={`${keyDate}group`}>
-                    {this.props.groupedItems[keyDate].map((_id) => <AgendaListItem
-                        key={_id}
-                        group={keyDate}
-                        item={itemsById[_id]}
-                        isActive={activeItem === _id}
-                        isSelected={selectedItems.indexOf(_id) !== -1}
-                        isRead={readItems[_id] === getIntVersion(itemsById[_id])}
-                        onClick={this.onItemClick}
-                        onDoubleClick={this.onItemDoubleClick}
-                        onActionList={this.onActionList}
-                        showActions={!!this.state.actioningItem && this.state.actioningItem._id === _id && keyDate === this.state.activeGroup}
-                        toggleSelected={() => this.props.dispatch(toggleSelected(_id))}
-                        actions={this.filterActions(itemsById[_id])}
-                        isExtended={isExtended}
-                        user={this.props.user}
-                        actioningItem={this.state.actioningItem}
-                        resetActioningItem={this.resetActioningItem}
-                    />)}
+                <div className = 'wire-articles__group' key={`${group.date}group`}>
+                    {group.items.map((_id, groupIndex) => {
+
+                        const plans = getPlanningItemsByGroup(itemsById[_id], group.date);
+
+                        if (plans.length > 0) {
+                            return (<Fragment key={`${_id}--${groupIndex}`}>
+                                {
+                                    plans.map((plan) =>
+                                        <AgendaListItem
+                                            key={`${_id}--${plan._id}`}
+                                            group={group.date}
+                                            item={itemsById[_id]}
+                                            isActive={this.isActiveItem(_id, group.date, plan)}
+                                            isSelected={selectedItems.indexOf(_id) !== -1}
+                                            isRead={readItems[_id] === getIntVersion(itemsById[_id])}
+                                            onClick={this.onItemClick}
+                                            onDoubleClick={this.onItemDoubleClick}
+                                            onActionList={this.onActionList}
+                                            showActions={!!this.state.actioningItem &&
+                                            this.state.actioningItem._id === _id &&
+                                            group.date === this.state.activeGroup &&
+                                            plan.guid === get(this.state.activePlan, 'guid')}
+                                            toggleSelected={() => this.props.dispatch(toggleSelected(_id))}
+                                            actions={this.filterActions(itemsById[_id])}
+                                            isExtended={isExtended}
+                                            user={this.props.user}
+                                            actioningItem={this.state.actioningItem}
+                                            planningItem={plan}
+                                            resetActioningItem={this.resetActioningItem}/>
+                                    )
+                                }
+                            </Fragment>);
+                        } else {
+                            return (<AgendaListItem
+                                key={_id}
+                                group={group.date}
+                                item={itemsById[_id]}
+                                isActive={this.isActiveItem(_id, group.date, null)}
+                                isSelected={selectedItems.indexOf(_id) !== -1}
+                                isRead={readItems[_id] === getIntVersion(itemsById[_id])}
+                                onClick={this.onItemClick}
+                                onDoubleClick={this.onItemDoubleClick}
+                                onActionList={this.onActionList}
+                                showActions={!!this.state.actioningItem &&
+                                this.state.actioningItem._id === _id && group.date === this.state.activeGroup}
+                                toggleSelected={() => this.props.dispatch(toggleSelected(_id))}
+                                actions={this.filterActions(itemsById[_id])}
+                                isExtended={isExtended}
+                                user={this.props.user}
+                                actioningItem={this.state.actioningItem}
+                                resetActioningItem={this.resetActioningItem}
+                            />);
+                        }
+                    })}
                 </div>
             ]
         );
@@ -195,8 +284,10 @@ class AgendaList extends React.Component {
 AgendaList.propTypes = {
     items: PropTypes.array.isRequired,
     itemsById: PropTypes.object,
-    activeItem: PropTypes.string,
+    activeItem: PropTypes.object,
     previewItem: PropTypes.string,
+    previewGroup: PropTypes.string,
+    previewPlan: PropTypes.object,
     dispatch: PropTypes.func.isRequired,
     selectedItems: PropTypes.array,
     readItems: PropTypes.object,
@@ -208,11 +299,12 @@ AgendaList.propTypes = {
     user: PropTypes.string,
     company: PropTypes.string,
     activeView: PropTypes.string,
-    groupedItems: PropTypes.object,
+    groupedItems: PropTypes.array,
     activeDate: PropTypes.number,
     activeFilter: PropTypes.object,
     activeNavigation: PropTypes.string,
     resultsFiltered: PropTypes.bool,
+    listItems: PropTypes.array,
 };
 
 const mapStateToProps = (state) => ({
@@ -220,6 +312,8 @@ const mapStateToProps = (state) => ({
     itemsById: state.itemsById,
     activeItem: state.activeItem,
     previewItem: state.previewItem,
+    previewGroup: state.previewGroup,
+    previewPlan: state.previewPlan,
     selectedItems: state.selectedItems,
     readItems: state.readItems,
     bookmarks: state.bookmarks,
@@ -230,6 +324,7 @@ const mapStateToProps = (state) => ({
     activeFilter: get(state, 'search.activeFilter'),
     activeNavigation: get(state, 'search.activeNavigation', null),
     resultsFiltered: state.resultsFiltered,
+    listItems: listItemsSelector(state),
 });
 
 export default connect(mapStateToProps)(AgendaList);

--- a/assets/agenda/components/AgendaListItem.jsx
+++ b/assets/agenda/components/AgendaListItem.jsx
@@ -1,11 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-
 import ActionButton from 'components/ActionButton';
 
 import AgendaListItemIcons from './AgendaListItemIcons';
-import {hasCoverages, isCanceled, isPostponed, isRescheduled, getName, isWatched} from '../utils';
+import {
+    hasCoverages,
+    isCanceled,
+    isPostponed,
+    isRescheduled,
+    getName,
+    isWatched,
+    getDescription,
+} from '../utils';
 import ActionMenu from '../../components/ActionMenu';
 import { LIST_ANIMATIONS } from 'utils';
 
@@ -41,7 +48,7 @@ class AgendaListItem extends React.Component {
     }
 
     render() {
-        const {item, onClick, onDoubleClick, isExtended, group} = this.props;
+        const {item, onClick, onDoubleClick, isExtended, group, planningItem} = this.props;
         const cardClassName = classNames('wire-articles__item-wrap col-12');
         const wrapClassName = classNames('wire-articles__item wire-articles__item--list', {
             'wire-articles__item--covering': hasCoverages(this.props.item),
@@ -51,6 +58,7 @@ class AgendaListItem extends React.Component {
             'wire-articles__item--canceled': isCanceled(this.props.item),
             'wire-articles__item--rescheduled': isRescheduled(this.props.item),
             'wire-articles__item--selected': this.props.isSelected,
+            'wire-articles__item--open': this.props.isActive,
         });
         const selectClassName = classNames('no-bindable-select', {
             'wire-articles__item-select-visible': !LIST_ANIMATIONS,
@@ -60,13 +68,15 @@ class AgendaListItem extends React.Component {
             'flex-column align-items-start': !isExtended
         });
 
+        const description = getDescription(item, planningItem || {});
+
         return (
             <article key={item._id}
                 className={cardClassName}
                 tabIndex='0'
                 ref={(elem) => this.articleElem = elem}
-                onClick={() => onClick(item, group)}
-                onDoubleClick={() => onDoubleClick(item, group)}
+                onClick={() => onClick(item, group, planningItem || {})}
+                onDoubleClick={() => onDoubleClick(item, group, planningItem || {})}
                 onMouseEnter={() => {
                     this.setState({isHover: true});
                     if (this.props.actioningItem && this.props.actioningItem._id !== item._id) {
@@ -91,11 +101,11 @@ class AgendaListItem extends React.Component {
                             {getName(item)}
                         </h4>
 
-                        <AgendaListItemIcons item={item} group={group} />
+                        <AgendaListItemIcons item={item} group={group} planningItem={planningItem} />
 
-                        {isExtended && item.definition_short && (
+                        {isExtended && description && (
                             <p className="wire-articles__item__text">
-                                {item.definition_short}
+                                {description}
                             </p>
                         )}
 
@@ -105,6 +115,7 @@ class AgendaListItem extends React.Component {
                         <div className='wire-articles__item-actions' onClick={this.stopPropagation}>
                             <ActionMenu
                                 item={this.props.item}
+                                plan={this.props.planningItem}
                                 user={this.props.user}
                                 group={this.props.group}
                                 actions={this.props.actions}
@@ -149,6 +160,7 @@ AgendaListItem.propTypes = {
     user: PropTypes.string,
     actioningItem: PropTypes.object,
     resetActioningItem: PropTypes.func,
+    planningItem: PropTypes.object,
 };
 
 export default AgendaListItem;

--- a/assets/agenda/components/AgendaListItemIcons.jsx
+++ b/assets/agenda/components/AgendaListItemIcons.jsx
@@ -18,7 +18,7 @@ import AgendaMetaTime from './AgendaMetaTime';
 import {gettext, formatDate, formatTime} from 'utils';
 
 
-function AgendaListItemIcons({item, group, hideCoverages, row}) {
+function AgendaListItemIcons({item, planningItem, group, hideCoverages, row}) {
     const className = bem('wire-articles', 'item__meta', {
         row,
     });
@@ -56,19 +56,23 @@ function AgendaListItemIcons({item, group, hideCoverages, row}) {
         return '';
     };
 
+
+
     return (
         <div className={className}>
             <AgendaMetaTime
                 item={item}
                 borderRight={true}
                 isRecurring={isRecurring(item)}
+                group={group}
             />
 
             {hasCoverages(item) && !hideCoverages &&
                 <div className='wire-articles__item__icons wire-articles__item__icons--dashed-border align-self-start'>
                     {item.coverages.map((coverage) => {
                         const coverageClass = `icon--coverage-${getCoverageIcon(coverage.coverage_type)}`;
-                        return (!group || isCoverageForExtraDay(coverage, group) &&
+                        return (!group || (isCoverageForExtraDay(coverage, group) &&
+                            coverage.planning_id === planningItem._id) &&
                           <span
                               className='wire-articles__item__icon'
                               key={coverage.coverage_id}
@@ -94,6 +98,7 @@ function AgendaListItemIcons({item, group, hideCoverages, row}) {
 
 AgendaListItemIcons.propTypes = {
     item: PropTypes.object,
+    planningItem: PropTypes.object,
     group: PropTypes.string,
     hideCoverages: PropTypes.bool,
     row: PropTypes.bool,

--- a/assets/agenda/components/AgendaListItemIcons.jsx
+++ b/assets/agenda/components/AgendaListItemIcons.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {get} from 'lodash';
 import {bem} from 'ui/utils';
 import {
     hasCoverages,
@@ -72,7 +73,7 @@ function AgendaListItemIcons({item, planningItem, group, hideCoverages, row}) {
                     {item.coverages.map((coverage) => {
                         const coverageClass = `icon--coverage-${getCoverageIcon(coverage.coverage_type)}`;
                         return (!group || (isCoverageForExtraDay(coverage, group) &&
-                            coverage.planning_id === planningItem._id) &&
+                            coverage.planning_id === get(planningItem, 'guid')) &&
                           <span
                               className='wire-articles__item__icon'
                               key={coverage.coverage_id}

--- a/assets/agenda/components/AgendaLongDescription.jsx
+++ b/assets/agenda/components/AgendaLongDescription.jsx
@@ -1,18 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
 
-export default function AgendaLongDescription({item}) {
-    if (!item.definition_long && !item.definition_short) {
+
+export default function AgendaLongDescription({item, plan}) {
+    if (!get(plan, 'description_text') && !item.definition_long && !item.definition_short) {
         return null;
     }
 
     return (
         <p className="wire-column__preview__text wire-column__preview__text--pre">
-            {item.definition_long || item.definition_short}
+            {get(plan, 'description_text') || item.definition_long || item.definition_short}
         </p>
     );
 }
 
 AgendaLongDescription.propTypes = {
     item: PropTypes.object.isRequired,
+    plan: PropTypes.object,
 };

--- a/assets/agenda/components/AgendaMetaTime.jsx
+++ b/assets/agenda/components/AgendaMetaTime.jsx
@@ -1,14 +1,40 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import {bem} from 'ui/utils';
-import {formatTime, formatDate, gettext, DAY_IN_MINUTES} from 'utils';
-import {hasCoverages} from '../utils';
 
-function format(agendaDate) {
-    const start = moment(agendaDate.start);
-    const end = moment(agendaDate.end);
-    const duration = end.diff(start, 'minutes');
+import {bem} from 'ui/utils';
+import {formatTime, formatDate, gettext, DAY_IN_MINUTES, DATE_FORMAT} from 'utils';
+import {hasCoverages, isCoverageForExtraDay} from '../utils';
+
+function format(item, group) {
+    let start = moment(item.dates.start);
+    let end = moment(item.dates.end);
+    let duration = end.diff(start, 'minutes');
+    let groupDate = moment(group, DATE_FORMAT);
+
+    const isGroupBetweenEventDates = start.isSameOrBefore(groupDate, 'day') && end.isSameOrAfter(groupDate, 'day');
+
+    if (!isGroupBetweenEventDates && hasCoverages(item)) {
+        // we rendering for extra days
+        const scheduleDates = item.coverages
+            .map((coverage) => {
+                if (isCoverageForExtraDay(coverage, group)) {
+                    return coverage.scheduled;
+                }
+                return null;
+            })
+            .filter((d) => d)
+            .sort((a, b) => {
+                if (a < b) return -1;
+                if (a > b) return 1;
+                return 0;
+            })
+        ;
+        if (scheduleDates.length > 0) {
+            duration = 0;
+            start = scheduleDates[0];
+        }
+    }
 
     if (duration > DAY_IN_MINUTES) {
         // Multi day event
@@ -49,7 +75,7 @@ function getCalendarClass(item) {
     }
 }
 
-export default function AgendaMetaTime({item, borderRight, isRecurring}) {
+export default function AgendaMetaTime({item, borderRight, isRecurring, group}) {
     return ([
         <div key="icon" className={bem('wire-articles__item', 'icons','dashed-border')}>
             <span className="wire-articles__item__icon">
@@ -58,7 +84,7 @@ export default function AgendaMetaTime({item, borderRight, isRecurring}) {
             </span>
         </div>,
         <div key="times" className={bem('wire-articles__item', 'meta-time', {'border-right': borderRight})}>
-            {format(item.dates)}
+            {format(item, group)}
         </div>
     ]);
 }
@@ -67,6 +93,7 @@ AgendaMetaTime.propTypes = {
     item: PropTypes.object,
     borderRight: PropTypes.bool,
     isRecurring: PropTypes.bool,
+    group: PropTypes.string,
 };
 
 AgendaMetaTime.defaultProps = {

--- a/assets/agenda/components/AgendaPreview.jsx
+++ b/assets/agenda/components/AgendaPreview.jsx
@@ -72,7 +72,8 @@ class AgendaPreview extends React.PureComponent {
                             <AgendaLongDescription item={item} plan={previewPlan}/>
                             <AgendaPreviewCoverages item={item}
                                 currentCoverage={displayCoverages.current}
-                                previousCoverage={displayCoverages.previous} />
+                                previousCoverage={displayCoverages.previous}
+                            />
                             <AgendaCoverageRequest item={item} requestCoverage={requestCoverage}/>
                             <AgendaPreviewAttachments item={item} />
                             <AgendaTags item={item} plan={previewPlan || {}} isItemDetail={false} />

--- a/assets/agenda/components/AgendaPreview.jsx
+++ b/assets/agenda/components/AgendaPreview.jsx
@@ -8,7 +8,14 @@ import PreviewActionButtons from 'components/PreviewActionButtons';
 
 import Preview from 'ui/components/Preview';
 
-import {hasCoverages, isCanceled, isPostponed, isRescheduled, getInternalNotes} from '../utils';
+import {
+    hasCoverages,
+    isCanceled,
+    isPostponed,
+    isRescheduled,
+    getInternalNote,
+    getCoveragesForDisplay,
+} from '../utils';
 import AgendaName from './AgendaName';
 import AgendaTime from './AgendaTime';
 import AgendaMeta from './AgendaMeta';
@@ -33,7 +40,7 @@ class AgendaPreview extends React.PureComponent {
     }
 
     render() {
-        const {item, user, actions, openItemDetails, requestCoverage, previewGroup} = this.props;
+        const {item, user, actions, openItemDetails, requestCoverage, previewGroup, previewPlan} = this.props;
 
         const isWatching = get(item, 'watches', []).includes(user);
 
@@ -46,6 +53,8 @@ class AgendaPreview extends React.PureComponent {
             'wire-column__preview--open': !!item,
             'wire-column__preview--watched': isWatching,
         });
+
+        const displayCoverages = getCoveragesForDisplay(item, previewPlan, previewGroup);
 
         return (
             <div className={previewClassName}>
@@ -60,13 +69,15 @@ class AgendaPreview extends React.PureComponent {
                             <AgendaTime item={item} group={previewGroup} />
                             <AgendaPreviewImage item={item} onClick={openItemDetails} />
                             <AgendaMeta item={item} />
-                            <AgendaLongDescription item={item} />
-                            <AgendaPreviewCoverages item={item} />
+                            <AgendaLongDescription item={item} plan={previewPlan}/>
+                            <AgendaPreviewCoverages item={item}
+                                currentCoverage={displayCoverages.current}
+                                previousCoverage={displayCoverages.previous} />
                             <AgendaCoverageRequest item={item} requestCoverage={requestCoverage}/>
                             <AgendaPreviewAttachments item={item} />
-                            <AgendaTags item={item} isItemDetail={false} />
-                            <AgendaEdNote item={item} />
-                            <AgendaInternalNote internalNotes={getInternalNotes(item)} />
+                            <AgendaTags item={item} plan={previewPlan || {}} isItemDetail={false} />
+                            <AgendaEdNote item={item} plan={previewPlan || {}}/>
+                            <AgendaInternalNote internalNote={getInternalNote(item, previewPlan || {})} />
                         </div>
                     </Preview>
                 }
@@ -88,6 +99,7 @@ AgendaPreview.propTypes = {
     openItemDetails: PropTypes.func,
     requestCoverage: PropTypes.func,
     previewGroup: PropTypes.string,
+    previewPlan: PropTypes.object,
 };
 
 export default AgendaPreview;

--- a/assets/agenda/components/AgendaPreviewCoverages.jsx
+++ b/assets/agenda/components/AgendaPreviewCoverages.jsx
@@ -1,22 +1,30 @@
-import React from 'react';
+import React, {Fragment} from 'react';
 import PropTypes from 'prop-types';
 import { gettext } from 'utils';
 
 import PreviewBox from 'ui/components/PreviewBox';
 import AgendaCoverages from './AgendaCoverages';
 
-export default function AgendaPreviewCoverages({item}) {
-    if (!item.coverages) {
+export default function AgendaPreviewCoverages({item, currentCoverage, previousCoverage}) {
+    if (!currentCoverage) {
         return null;
     }
 
     return (
-        <PreviewBox label={gettext('Coverages')}>
-            <AgendaCoverages item={item} />
-        </PreviewBox>
+        <Fragment>
+            <PreviewBox label={gettext('Coverages')}>
+                <AgendaCoverages item={item} coverages={currentCoverage}/>
+            </PreviewBox>
+
+            {previousCoverage.length > 0 && <PreviewBox label={gettext('Previous Coverages')}>
+                <AgendaCoverages item={item} coverages={previousCoverage}/>
+            </PreviewBox>}
+        </Fragment>
     );
 }
 
 AgendaPreviewCoverages.propTypes = {
     item: PropTypes.object,
+    currentCoverage: PropTypes.arrayOf(PropTypes.object),
+    previousCoverage: PropTypes.arrayOf(PropTypes.object),
 };

--- a/assets/agenda/components/AgendaPreviewCoverages.jsx
+++ b/assets/agenda/components/AgendaPreviewCoverages.jsx
@@ -1,22 +1,19 @@
 import React, {Fragment} from 'react';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
 import { gettext } from 'utils';
 
 import PreviewBox from 'ui/components/PreviewBox';
 import AgendaCoverages from './AgendaCoverages';
 
 export default function AgendaPreviewCoverages({item, currentCoverage, previousCoverage}) {
-    if (!currentCoverage) {
-        return null;
-    }
-
     return (
         <Fragment>
-            <PreviewBox label={gettext('Coverages')}>
+            {get(currentCoverage, 'length', 0) > 0 && <PreviewBox label={gettext('Coverages')}>
                 <AgendaCoverages item={item} coverages={currentCoverage}/>
-            </PreviewBox>
+            </PreviewBox>}
 
-            {previousCoverage.length > 0 && <PreviewBox label={gettext('Previous Coverages')}>
+            {get(previousCoverage, 'length', 0) > 0 && <PreviewBox label={gettext('Previous Coverages')}>
                 <AgendaCoverages item={item} coverages={previousCoverage}/>
             </PreviewBox>}
         </Fragment>

--- a/assets/agenda/components/AgendaTags.jsx
+++ b/assets/agenda/components/AgendaTags.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { gettext } from 'utils';
-import { isEmpty } from 'lodash';
+import { isEmpty, uniqBy } from 'lodash';
 import InfoBox from 'wire/components/InfoBox';
 import PreviewTagsBlock from 'wire/components/PreviewTagsBlock';
 import PreviewTagsLink from 'wire/components/PreviewTagsLink';
@@ -9,15 +9,15 @@ import {getSubjects} from '../utils';
 
 function formatCV(items, field) {
     return items && items.map((item) => (
-        <PreviewTagsLink key={item.qcode}
+        <PreviewTagsLink key={item.code}
             href={`/agenda?q=${field}:"${item.name}"`}
             text={item.name}
         />
     ));
 }
 
-function AgendaTags({item, isItemDetail}) {
-    const subjects = getSubjects(item);
+function AgendaTags({item, plan, isItemDetail}) {
+    const subjects = uniqBy([...getSubjects(item), ...getSubjects(plan)], 'code');
     const formattedSubjects = !isEmpty(subjects) && formatCV(subjects, 'subject.name');
 
     return (
@@ -31,6 +31,7 @@ function AgendaTags({item, isItemDetail}) {
 
 AgendaTags.propTypes = {
     item: PropTypes.object,
+    plan: PropTypes.object,
     isItemDetail: PropTypes.bool,
 };
 

--- a/assets/agenda/components/AgendaTime.jsx
+++ b/assets/agenda/components/AgendaTime.jsx
@@ -8,7 +8,7 @@ import AgendaListItemLabels from './AgendaListItemLabels';
 
 export default function AgendaTime({item, group}) {
     const getDates = () => {
-        const dates = formatAgendaDate(item.dates, group);
+        const dates = formatAgendaDate(item, group);
         if (dates[1]) {
             return [<div key='time' className={bem('wire-column__preview', 'date', 'dashed-border')}>{dates[0]}</div>, dates[1]];
         }

--- a/assets/agenda/reducers.js
+++ b/assets/agenda/reducers.js
@@ -8,7 +8,7 @@ import {
     UPDATE_ITEMS,
 } from './actions';
 
-import { get, isEmpty } from 'lodash';
+import { get, isEmpty, uniqBy } from 'lodash';
 import { getActiveDate } from 'local-store';
 import { EXTENDED_VIEW } from 'wire/defaults';
 import { searchReducer } from 'search/reducers';
@@ -23,6 +23,7 @@ const initialState = {
     activeItem: null,
     previewItem: null,
     previewGroup: null,
+    previewPlan: null,
     openItem: null,
     isLoading: false,
     resultsFiltered: false,
@@ -48,6 +49,27 @@ const initialState = {
     detail: false,
     userSections: {}
 };
+
+function processAggregations(aggregations) {
+    if (!get(aggregations, 'planning_items.doc_count', false)) {
+        return null;
+    }
+
+    const planningItems = get(aggregations, 'planning_items', {});
+
+    Object.keys(planningItems).forEach((key) => {
+        if (key !== 'doc_count' && planningItems[key].buckets) {
+            if (!get(aggregations, `${key}.buckets`)) {
+                aggregations[key] = {'buckets': planningItems[key].buckets};
+            } else {
+                aggregations[key] = {
+                    'buckets': uniqBy([...planningItems[key].buckets, ...get(aggregations, `${key}.buckets`)], 'key')
+                };
+            }
+        }
+    });
+    return aggregations;
+}
 
 function recieveItems(state, data) {
     const itemsById = Object.assign({}, state.itemsById);
@@ -89,7 +111,7 @@ function recieveItems(state, data) {
         itemsById,
         isLoading: false,
         totalItems: data._meta.total,
-        aggregations: data._aggregations || null,
+        aggregations: processAggregations(data._aggregations) || null,
         newItems: [],
         newItemsData: null,
         agenda,

--- a/assets/agenda/tests/utils.spec.js
+++ b/assets/agenda/tests/utils.spec.js
@@ -1,4 +1,6 @@
+import { keyBy } from 'lodash';
 import * as utils from '../utils';
+
 
 describe('utils', () => {
     describe('groupItems', () => {
@@ -14,14 +16,14 @@ describe('utils', () => {
                 },
             ];
 
-            const groupedItems = utils.groupItems(items, '2018-10-13', 'day');
+            const groupedItems = keyBy(utils.groupItems(items, '2018-10-13', 'day'), 'date');
 
             expect(groupedItems.hasOwnProperty('13-10-2018')).toBe(false);
             expect(groupedItems.hasOwnProperty('14-10-2018')).toBe(false);
-            expect(groupedItems['15-10-2018']).toEqual(['foo']);
+            expect(groupedItems['15-10-2018']['items']).toEqual(['foo']);
             expect(groupedItems.hasOwnProperty('16-10-2018')).toBe(false);
             expect(groupedItems.hasOwnProperty('17-10-2018')).toBe(false);
-            expect(groupedItems['18-10-2018']).toEqual(['bar']);
+            expect(groupedItems['18-10-2018']['items']).toEqual(['bar']);
         });
 
         it('returns grouped multi day events per day', () => {
@@ -36,12 +38,12 @@ describe('utils', () => {
                 },
             ];
 
-            const groupedItems = utils.groupItems(items, '2018-10-16', 'day');
+            const groupedItems = keyBy(utils.groupItems(items, '2018-10-16', 'day'), 'date');
 
             expect(groupedItems.hasOwnProperty('15-10-2018')).toBe(false);
-            expect(groupedItems['16-10-2018']).toEqual(['foo']);
-            expect(groupedItems['17-10-2018']).toEqual(['foo', 'bar']);
-            expect(groupedItems['18-10-2018']).toEqual(['bar']);
+            expect(groupedItems['16-10-2018']['items']).toEqual(['foo']);
+            expect(groupedItems['17-10-2018']['items']).toEqual(['foo', 'bar']);
+            expect(groupedItems['18-10-2018']['items']).toEqual(['bar']);
             expect(groupedItems.hasOwnProperty('19-10-2018')).toBe(false);
         });
 
@@ -53,17 +55,77 @@ describe('utils', () => {
                     display_dates: [{date: '2018-10-13T10:00:00+0000'}]
                 }];
 
-            const groupedItems = utils.groupItems(items, '2018-10-11', 'day');
+            const groupedItems = keyBy(utils.groupItems(items, '2018-10-11', 'day'), 'date');
 
             expect(groupedItems.hasOwnProperty('11-10-2018')).toBe(false);
             expect(groupedItems.hasOwnProperty('12-10-2018')).toBe(false);
-            expect(groupedItems['13-10-2018']).toEqual(['foo']);
+            expect(groupedItems['13-10-2018']['items']).toEqual(['foo']);
             expect(groupedItems.hasOwnProperty('14-10-2018')).toBe(false);
-            expect(groupedItems['15-10-2018']).toEqual(['foo']);
-            expect(groupedItems['16-10-2018']).toEqual(['foo']);
-            expect(groupedItems['17-10-2018']).toEqual(['foo']);
+            expect(groupedItems['15-10-2018']['items']).toEqual(['foo']);
+            expect(groupedItems['16-10-2018']['items']).toEqual(['foo']);
+            expect(groupedItems['17-10-2018']['items']).toEqual(['foo']);
             expect(groupedItems.hasOwnProperty('18-10-2018')).toBe(false);
         });
     });
 
+    describe('listItems', () => {
+        it('of event with planning items', () => {
+            const items = [
+                {
+                    _id: 'foo',
+                    dates: {start: '2018-10-15T04:00:00+0000', end: '2018-10-15T05:00:00+0000', tz: 'Australia/Sydney'},
+                    display_dates: [
+                        {date: '2018-10-14T04:00:00+0000'},
+                        {date: '2018-10-16T04:00:00+0000'},
+                    ],
+                    coverages: [
+                        {
+                            'scheduled': '2018-10-15T04:00:00+0000',
+                            'planning_id': 'plan1',
+                            'coverage_id': 'coverage1'
+                        },
+                        {
+                            'scheduled': '2018-10-14T04:00:00+0000',
+                            'planning_id': 'plan1',
+                            'coverage_id': 'coverage2'
+                        },
+                        {
+                            'scheduled': '2018-10-16T04:00:00+0000',
+                            'planning_id': 'plan2',
+                            'coverage_id': 'coverage3'
+                        }
+                    ],
+                    planning_items: [
+                        {
+                            '_id': 'plan1',
+                            'guid': 'plan1',
+                            'planning_date': '2018-10-15T04:30:00+0000',
+                        },
+                        {
+                            '_id': 'plan2',
+                            'guid': 'plan2',
+                            'planning_date': '2018-10-15T04:30:00+0000',
+                        }
+                    ]
+                }
+            ];
+
+            const groupedItems = utils.groupItems(items, '2018-10-11', 'day');
+            const itemsById = keyBy(items, '_id');
+            const listItems = keyBy(utils.getListItems(groupedItems, itemsById), 'group');
+
+            expect(groupedItems.hasOwnProperty('11-10-2018')).toBe(false);
+            expect(groupedItems.hasOwnProperty('12-10-2018')).toBe(false);
+            expect(groupedItems.hasOwnProperty('13-10-2018')).toBe(false);
+            expect(listItems.hasOwnProperty('14-10-2018')).toBe(true);
+            expect(listItems.hasOwnProperty('15-10-2018')).toBe(true);
+            expect(listItems.hasOwnProperty('16-10-2018')).toBe(true);
+            expect(listItems['14-10-2018']['_id']).toBe('foo');
+            expect(listItems['14-10-2018']['plan']['guid']).toBe('plan1');
+            expect(listItems['15-10-2018']['_id']).toBe('foo');
+            expect(listItems['15-10-2018']['plan']['guid']).toBe('plan1');
+            expect(listItems['16-10-2018']['_id']).toBe('foo');
+            expect(listItems['16-10-2018']['plan']['guid']).toBe('plan2');
+        });
+    });
 });

--- a/assets/agenda/utils.js
+++ b/assets/agenda/utils.js
@@ -1,6 +1,6 @@
-import { get, isEmpty, includes } from 'lodash';
+import { get, isEmpty, includes, keyBy, sortBy } from 'lodash';
 import moment from 'moment/moment';
-import {formatDate, formatMonth, formatWeek, getConfig, gettext} from '../utils';
+import {formatDate, formatMonth, formatWeek, getConfig, gettext, DATE_FORMAT} from '../utils';
 
 const STATUS_KILLED = 'killed';
 const STATUS_CANCELED = 'cancelled';
@@ -383,11 +383,8 @@ export function getAttachments(item) {
  * @param {Object} item
  * @return {Array}
  */
-export function getInternalNotes(item) {
-    const internalNotes = [];
-    internalNotes.push(get(item, 'event.internal_note'));
-    (get(item, 'planning_items', []) || []).forEach(p => internalNotes.push(p.internal_note));
-    return internalNotes.filter(note => !!note);
+export function getInternalNote(item, plan) {
+    return get(plan, 'internal_note') || get(item, 'internal_note');
 }
 
 /**
@@ -412,7 +409,7 @@ export function getInternalNotesFromCoverages(item) {
  * @return {Array}
  */
 export function getSubjects(item) {
-    return get(item, 'subject', []);
+    return get(item, 'subject') || [];
 }
 
 /**
@@ -432,7 +429,18 @@ export function hasAttachments(item) {
  * @return {String}
  */
 export function getName(item) {
-    return item.name || item.headline;
+    return item.name || item.slugline || item.headline;
+}
+
+/**
+ * Get agenda item description
+ *
+ * @param {Object} item
+ * @param {Object} plan
+ * @return {String}
+ */
+export function getDescription(item, plan) {
+    return plan.description_text || item.definition_short;
 }
 
 
@@ -497,5 +505,89 @@ export function groupItems (items, activeDate, activeGrouping) {
         }
     });
 
-    return groupedItems;
+    return sortBy(Object.keys(groupedItems).map((k) => ({date: k, items: groupedItems[k]})), 'date');
+}
+
+/**
+ * Get Planning Item for the day
+ * @param item: Agenda item
+ * @param group: Group Date
+ */
+export function getPlanningItemsByGroup(item, group) {
+    if (get(item, 'planning_items.length', 0) === 0) {
+        return [];
+    }
+
+    if (get(item, 'coverages.length', 0) === 0) {
+        return [];
+    }
+
+    const allPlans = keyBy(get(item, 'planning_items'), '_id');
+    const processed = {};
+
+    // get unique plans for that group based on the coverage.
+    const plans = item.coverages
+        .map((coverage) => {
+            if (isCoverageForExtraDay(coverage, group)) {
+                if (!processed[coverage.planning_id]) {
+                    processed[coverage.planning_id] = 1;
+                    return allPlans[coverage.planning_id];
+                }
+                return null;
+            }
+            return null;
+        })
+        .filter((p) => p);
+
+    if (plans.length === 0) {
+        return [];
+    }
+
+    return plans;
+}
+
+export function isCoverageOnPreviousDay(coverage, group) {
+    return moment(coverage.scheduled).isBefore(moment(group, DATE_FORMAT), 'day');
+}
+
+
+export function getCoveragesForDisplay(item, plan, group) {
+    const currentCoverage = [];
+    const previousCoverage = [];
+    // get current and preview coverages
+    if (!get(plan, 'guid')) {
+        currentCoverage.push(...(get(item, 'coverages') || []));
+    } else {
+        get(item, 'coverages', [])
+            .forEach((coverage) => {
+                if (coverage.planning_id === get(plan, 'guid')) {
+                    if (isCoverageForExtraDay(coverage, group)) {
+                        currentCoverage.push(coverage);
+                    } else if (isCoverageOnPreviousDay(coverage, group)) {
+                        previousCoverage.push(coverage);
+                    }
+                }
+            });
+    }
+
+    return {current: currentCoverage, previous: previousCoverage};
+}
+
+export function getListItems(groups, itemsById) {
+    const listItems = [];
+
+    groups.forEach((group) => {
+        group.items.forEach((_id) => {
+            const plans = getPlanningItemsByGroup(itemsById[_id], group.date);
+            // console.log(plans);
+            if (plans.length > 0) {
+                plans.forEach((plan) => {
+                    listItems.push({_id, group: group.date, plan});
+                });
+            } else {
+                listItems.push({_id, group: group.date, plan: null});
+            }
+        });
+    });
+    return listItems;
 }

--- a/assets/agenda/utils.js
+++ b/assets/agenda/utils.js
@@ -555,20 +555,16 @@ export function getCoveragesForDisplay(item, plan, group) {
     const currentCoverage = [];
     const previousCoverage = [];
     // get current and preview coverages
-    if (!get(plan, 'guid')) {
-        currentCoverage.push(...(get(item, 'coverages') || []));
-    } else {
-        get(item, 'coverages', [])
-            .forEach((coverage) => {
-                if (coverage.planning_id === get(plan, 'guid')) {
-                    if (isCoverageForExtraDay(coverage, group)) {
-                        currentCoverage.push(coverage);
-                    } else if (isCoverageOnPreviousDay(coverage, group)) {
-                        previousCoverage.push(coverage);
-                    }
+    get(item, 'coverages', [])
+        .forEach((coverage) => {
+            if (coverage.planning_id === get(plan, 'guid')) {
+                if (isCoverageForExtraDay(coverage, group)) {
+                    currentCoverage.push(coverage);
+                } else if (isCoverageOnPreviousDay(coverage, group)) {
+                    previousCoverage.push(coverage);
                 }
-            });
-    }
+            }
+        });
 
     return {current: currentCoverage, previous: previousCoverage};
 }

--- a/assets/components/ActionButton.jsx
+++ b/assets/components/ActionButton.jsx
@@ -19,11 +19,21 @@ class ActionButton extends React.Component {
         const classes = classNames(`icon--${this.props.action.icon}`, {
             'icon--gray': this.props.isVisited,
         });
+        const {item, group, plan, action} = this.props;
+
         return (
             <button
                 type='button'
                 className={this.props.className}
-                onClick={() => this.props.action.action(this.props.action.multi ? [this.props.item._id] : this.props.item)}
+                onClick={
+                    () => {
+                        if (action.multi) {
+                            return action.action([item._id]);
+                        } else {
+                            return action.action(item, group, plan);
+                        }
+                    }
+                }
                 ref={(elem) => this.elem = elem}
                 title={!this.props.displayName ? this.props.action.name : ''}>
                 <i className={classes}></i>
@@ -34,6 +44,8 @@ class ActionButton extends React.Component {
 
 ActionButton.propTypes = {
     item: PropTypes.object,
+    group: PropTypes.string,
+    plan: PropTypes.object,
     className: PropTypes.string,
     displayName: PropTypes.bool,
     isVisited: PropTypes.bool,

--- a/assets/components/ActionList.jsx
+++ b/assets/components/ActionList.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ActionButton from './ActionButton';
 
 
-function ActionList({item, user, actions, onMouseLeave}) {
+function ActionList({item, group, plan, user, actions, onMouseLeave}) {
     return (
         <div onMouseLeave={onMouseLeave}>
             {actions.map((action) => !action.shortcut &&
@@ -14,6 +14,8 @@ function ActionList({item, user, actions, onMouseLeave}) {
                     isVisited={action.visited && action.visited(user, item)}
                     displayName={true}
                     item={item}
+                    group={group}
+                    plan={plan}
                 />
             )}
         </div>
@@ -22,6 +24,8 @@ function ActionList({item, user, actions, onMouseLeave}) {
 
 ActionList.propTypes = {
     item: PropTypes.object,
+    group: PropTypes.string,
+    plan: PropTypes.object,
     user: PropTypes.string,
     actions: PropTypes.arrayOf(PropTypes.shape({
         name: PropTypes.string.isRequired,

--- a/assets/components/ActionMenu.jsx
+++ b/assets/components/ActionMenu.jsx
@@ -16,12 +16,12 @@ class ActionMenu extends React.Component {
     }
 
     render() {
-        const { item, user, actions, group, onActionList, showActions } = this.props;
+        const { item, plan, user, actions, group, onActionList, showActions } = this.props;
         return (
             <div className='btn-group'>
                 <span
                     ref={(elem) => this.referenceElem = elem}
-                    onClick={(event) => onActionList(event, item, group)}>
+                    onClick={(event) => onActionList(event, item, group, plan)}>
                     <i className='icon--more icon--gray-light'></i>
                 </span>
                 {this.referenceElem &&
@@ -29,6 +29,8 @@ class ActionMenu extends React.Component {
                   <PopoverBody>
                       <ActionList
                           item={item}
+                          group={group}
+                          plan={plan}
                           user={user}
                           actions={actions}
                           onMouseLeave={this.onMouseLeave}
@@ -43,6 +45,7 @@ class ActionMenu extends React.Component {
 ActionMenu.propTypes = {
     item: PropTypes.object,
     user: PropTypes.string,
+    plan: PropTypes.object,
     actions: PropTypes.arrayOf(PropTypes.shape({
         name: PropTypes.string.isRequired,
         icon: PropTypes.string.isRequired,

--- a/assets/item-actions.js
+++ b/assets/item-actions.js
@@ -19,7 +19,7 @@ export function getItemActions(dispatch, actions) {
             name: gettext('Open'),
             icon: 'text',
             when: (state) => !state.itemToOpen && !state.openItem,
-            action: (item) => dispatch(openItem(item)),
+            action: (item, group, plan) => dispatch(openItem(item, group, plan)),
         },
         {
             name: gettext('Share'),

--- a/assets/products/components/EditProduct.jsx
+++ b/assets/products/components/EditProduct.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
+
 import TextInput from 'components/TextInput';
 import CheckboxInput from 'components/CheckboxInput';
 
@@ -12,6 +14,8 @@ class EditProduct extends React.Component {
         super(props);
         this.handleTabClick = this.handleTabClick.bind(this);
         this.getPoductTestButton = this.getPoductTestButton.bind(this);
+        this.getQueryString = this.getQueryString.bind(this);
+
         this.state = {
             activeTab: 'product-details',
             activeProduct: props.product._id,
@@ -35,7 +39,17 @@ class EditProduct extends React.Component {
     }
 
     getPoductTestButton(product) {
-        const q = getProductQuery(product);
+        let q;
+
+        if (product.product_type === 'agenda') {
+            q = JSON.stringify({
+                query: product.query,
+                planning_item_query: product.planning_item_query
+            });
+        } else {
+            q = getProductQuery(product);
+        }
+
 
         if (q) {
             return (
@@ -44,6 +58,13 @@ class EditProduct extends React.Component {
                 </a>
             );
         }
+    }
+
+    getQueryString(product, field) {
+        if (get(product, field) && product.product_type === 'agenda') {
+            return JSON.stringify({[field]: get(product, field)});
+        }
+        return get(product, field);
     }
 
     render() {
@@ -117,10 +138,24 @@ class EditProduct extends React.Component {
                                             onChange={this.props.onChange}
                                         />
                                         {this.props.product.query &&
-                                        <a href={`/${this.props.product.product_type || 'wire'}?q=${this.props.product.query}`} target="_blank"
+                                        <a href={`/${this.props.product.product_type || 'wire'}?q=${this.getQueryString(this.props.product, 'query')}`} target="_blank"
                                             className='btn btn-outline-secondary float-right mt-3'>{gettext('Test query')}
                                         </a>}
                                     </div>
+
+                                    {this.props.product.product_type === 'agenda' && <div className="form-group">
+                                        <label htmlFor="query">{gettext('Planning Item Query')}</label>
+                                        <textarea className="form-control"
+                                            id="planning_item_query"
+                                            name="planning_item_query"
+                                            value={this.props.product.planning_item_query || ''}
+                                            onChange={this.props.onChange}
+                                        />
+                                        {this.props.product.planning_item_query &&
+                                        <a href={`/${this.props.product.product_type || 'wire'}?q=${this.getQueryString(this.props.product, 'planning_item_query')}`} target="_blank"
+                                            className='btn btn-outline-secondary float-right mt-3'>{gettext('Test Planning Item query')}
+                                        </a>}
+                                    </div>}
 
                                     <CheckboxInput
                                         name='is_enabled'

--- a/assets/products/components/ProductList.jsx
+++ b/assets/products/components/ProductList.jsx
@@ -4,7 +4,7 @@ import ProductListItem from './ProductListItem';
 import { gettext } from 'utils';
 
 
-function ProductList({products, onClick, activeProductId}) {
+function ProductList({products, onClick, activeProductId, activeSection}) {
     const list = products.map((product) =>
         <ProductListItem
             key={product._id}
@@ -23,6 +23,7 @@ function ProductList({products, onClick, activeProductId}) {
                             <th>{ gettext('Status') }</th>
                             <th>{ gettext('Superdesk Product Id') }</th>
                             <th>{ gettext('Query') }</th>
+                            {activeSection === 'agenda' && <th>{ gettext('Planning Item Query')}</th>}
                             <th>{ gettext('Created On') }</th>
                         </tr>
                     </thead>
@@ -36,7 +37,8 @@ function ProductList({products, onClick, activeProductId}) {
 ProductList.propTypes = {
     products: PropTypes.array.isRequired,
     onClick: PropTypes.func.isRequired,
-    activeProductId: PropTypes.string
+    activeProductId: PropTypes.string,
+    activeSection: PropTypes.string
 };
 
 export default ProductList;

--- a/assets/products/components/ProductListItem.jsx
+++ b/assets/products/components/ProductListItem.jsx
@@ -12,6 +12,7 @@ function ProductListItem({product, isActive, onClick}) {
             <td>{(product.is_enabled ? gettext('Enabled') : gettext('Disabled'))}</td>
             <td>{gettext(product.sd_product_id)}</td>
             <td>{gettext(product.query)}</td>
+            {product.product_type === 'agenda' && <td>{gettext(product.planning_item_query)}</td>}
             <td>{shortDate(product._created)}</td>
         </tr>
     );

--- a/assets/products/components/Products.jsx
+++ b/assets/products/components/Products.jsx
@@ -84,6 +84,7 @@ class Products extends React.Component {
                         <ProductList
                             products={this.props.products.filter(sectionFilter)}
                             onClick={this.props.selectProduct}
+                            activeSection={this.props.activeSection}
                             activeProductId={this.props.activeProductId} />
                     </div>
                 )}

--- a/assets/reducers.js
+++ b/assets/reducers.js
@@ -112,6 +112,7 @@ export function defaultReducer(state, action) {
             readItems,
             previewItem: action.item ? action.item._id : null,
             previewGroup: action.group,
+            previewPlan: action.plan,
         };
     }
 
@@ -129,6 +130,7 @@ export function defaultReducer(state, action) {
             itemsById,
             openItem: action.item || null,
             previewGroup: action.group || null,
+            previewPlan: action.plan,
         };
     }
 

--- a/assets/wire/components/SearchResultsInfo.jsx
+++ b/assets/wire/components/SearchResultsInfo.jsx
@@ -41,9 +41,9 @@ class SearchResultsInfo extends React.Component {
         const displayFollowTopic = this.props.topicType && this.props.user &&
             !this.props.bookmarks && (this.props.resultsFiltered || this.props.query);
 
-        const displayTotalItems = this.props.bookmarks ||
+        const displayTotalItems = this.props.hideTotalItems && (this.props.bookmarks ||
           !isEmpty(this.props.activeTopic) ||
-          this.props.resultsFiltered || this.props.query;
+          this.props.resultsFiltered || this.props.query);
 
         const displayHeader = !isEmpty(this.props.newItems) || displayTotalItems || displayFollowTopic || this.props.query;
         return (
@@ -112,6 +112,11 @@ SearchResultsInfo.propTypes = {
     searchCriteria: PropTypes.object,
     resultsFiltered: PropTypes.bool,
     followTopic: PropTypes.func.isRequired,
+    hideTotalItems: PropTypes.bool,
+};
+
+SearchResultsInfo.defaultProps = {
+    hideTotalItems: true
 };
 
 const mapStateToProps = (state) => ({

--- a/newsroom/agenda/agenda.py
+++ b/newsroom/agenda/agenda.py
@@ -1,15 +1,14 @@
 import logging
 
 from content_api.items.resource import code_mapping
-from eve.utils import ParsedRequest
+from eve.utils import ParsedRequest, config
 from flask import json, abort, url_for, current_app as app
 from flask_babel import gettext
 from planning.common import WORKFLOW_STATE_SCHEMA
 from planning.events.events_schema import events_schema
 from planning.planning.planning import planning_schema
 from superdesk import get_resource_service
-from superdesk.metadata.item import not_analyzed
-from superdesk.resource import Resource, not_enabled
+from superdesk.resource import Resource, not_enabled, not_analyzed, not_indexed
 from superdesk.utils import ListCursor
 
 import newsroom
@@ -19,7 +18,7 @@ from newsroom.companies import get_user_company
 from newsroom.notifications import push_notification
 from newsroom.template_filters import is_admin_or_internal
 from newsroom.utils import get_user_dict, get_company_dict, filter_active_users
-from newsroom.wire.search import query_string, set_product_query, FeaturedQuery
+from newsroom.wire.search import query_string, set_product_query, FeaturedQuery, planning_items_query_string
 from newsroom.wire.utils import get_local_date, get_end_date
 
 logger = logging.getLogger(__name__)
@@ -80,7 +79,6 @@ class AgendaResource(newsroom.Resource):
     schema['slugline'] = not_analyzed
     schema['definition_short'] = events_schema['definition_short']
     schema['definition_long'] = events_schema['definition_long']
-    schema['abstract'] = planning_schema['abstract']
     schema['headline'] = planning_schema['headline']
     schema['firstcreated'] = events_schema['firstcreated']
     schema['version'] = events_schema['version']
@@ -88,12 +86,11 @@ class AgendaResource(newsroom.Resource):
     schema['ednote'] = events_schema['ednote']
 
     # aggregated fields
-    schema['genre'] = planning_schema['genre']
     schema['subject'] = planning_schema['subject']
-    schema['priority'] = planning_schema['priority']
     schema['urgency'] = planning_schema['urgency']
     schema['place'] = planning_schema['place']
     schema['service'] = code_mapping
+    schema['state_reason'] = {'type': 'string'}
 
     # dates
     schema['dates'] = {
@@ -109,7 +106,7 @@ class AgendaResource(newsroom.Resource):
     schema['display_dates'] = {
         'type': 'list',
         'nullable': True,
-        'mappping': {
+        'schema': {
             'type': 'dict',
             'schema': {
                 'date': {'type': 'datetime'},
@@ -161,7 +158,42 @@ class AgendaResource(newsroom.Resource):
     # planning details which can be more than one per event
     schema['planning_items'] = {
         'type': 'list',
-        'mapping': not_enabled,
+        'mapping': {
+            'type': 'nested',
+            'include_in_all': False,
+            'properties': {
+                '_id': not_analyzed,
+                'guid': not_analyzed,
+                'slugline': not_analyzed,
+                'description_text': {'type': 'string'},
+                'headline': {'type': 'string'},
+                'abstract': {'type': 'string'},
+                'subject': code_mapping,
+                'urgency': {'type': 'integer'},
+                'service': code_mapping,
+                'planning_date': {'type': 'date'},
+                'coverages': not_enabled,
+                'agendas': {
+                    'type': 'object',
+                    'properties': {
+                        'name': not_analyzed,
+                        '_id': not_analyzed,
+                    }
+                },
+                'ednote': {'type': 'string'},
+                'internal_note': not_indexed,
+                'place': planning_schema['place']['mapping'],
+                'state': not_analyzed,
+                'state_reason': {'type': 'string'},
+                'products': {
+                    'type': 'object',
+                    'properties': {
+                        'code': not_analyzed,
+                        'name': not_analyzed
+                    }
+                }
+            }
+        }
     }
 
     schema['bookmarks'] = Resource.not_analyzed_field('list')  # list of user ids who bookmarked this item
@@ -231,7 +263,6 @@ def _display_date_range(args):
 aggregations = {
     'calendar': {'terms': {'field': 'calendars.name', 'size': 0}},
     'location': {'terms': {'field': 'location.name', 'size': 0}},
-    'genre': {'terms': {'field': 'genre.name', 'size': 50}},
     'service': {'terms': {'field': 'service.name', 'size': 50}},
     'subject': {'terms': {'field': 'subject.name', 'size': 20}},
     'urgency': {'terms': {'field': 'urgency'}},
@@ -239,6 +270,17 @@ aggregations = {
     'coverage': {
         'nested': {'path': 'coverages'},
         'aggs': {'coverage_type': {'terms': {'field': 'coverages.coverage_type', 'size': 10}}}},
+    'planning_items': {
+        'nested': {
+            'path': 'planning_items',
+        },
+        'aggs': {
+            'service': {'terms': {'field': 'planning_items.service.name', 'size': 50}},
+            'subject': {'terms': {'field': 'planning_items.subject.name', 'size': 20}},
+            'urgency': {'terms': {'field': 'planning_items.urgency'}},
+            'place': {'terms': {'field': 'planning_items.place.name', 'size': 50}}
+        },
+    }
 }
 
 
@@ -252,7 +294,27 @@ def _filter_terms(filters):
     term_filters = []
     for key, val in filters.items():
         if val and key != 'coverage':
-            term_filters.append({'terms': {get_aggregation_field(key): val}})
+            if key in {'service', 'urgency', 'subject', 'place'}:
+                term_filters.append({
+                    'or': [
+                        {'terms': {get_aggregation_field(key): val}},
+                        {
+                            'nested': {
+                                'path': 'planning_items',
+                                'inner_hits': {},
+                                'query': {
+                                    'bool': {
+                                        'must': [
+                                            {'terms': {'planning_items.{}'.format(get_aggregation_field(key)): val}},
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                })
+            else:
+                term_filters.append({'terms': {get_aggregation_field(key): val}})
         if val and key == 'coverage':
             term_filters.append(
                 {"nested": {
@@ -285,8 +347,33 @@ def set_post_filter(source, req):
             source['query']['bool']['must'] += _filter_terms(filters)
 
 
+def get_agenda_query(query):
+    return {
+        'or': [
+            query_string(query),
+            planning_items_query_string(query)
+        ]
+    }
+
+
 class AgendaService(newsroom.Service):
     section = 'agenda'
+
+    def on_fetched(self, doc):
+        self._enhance_items(doc[config.ITEMS])
+
+    def on_fetched_item(self, doc):
+        self._enhance_items([doc])
+
+    def _enhance_items(self, docs):
+        for doc in docs:
+            inner_hits = doc.pop('inner_hits', None)
+            if not inner_hits or not inner_hits.get('planning_items'):
+                continue
+
+            items_by_key = {p.get('guid'): p for p in inner_hits.get('planning_items')}
+            doc['planning_items'] = [p for p in doc['planning_items']
+                                     if items_by_key.get(p.get('guid'))]
 
     def get(self, req, lookup):
         query = _agenda_query()
@@ -301,7 +388,22 @@ class AgendaService(newsroom.Service):
             return self.featured(req, lookup)
 
         if req.args.get('q'):
-            query['bool']['must'].append(query_string(req.args['q']))
+            test_query = {'or': []}
+            try:
+                q = json.loads(req.args.get('q'))
+                if isinstance(q, dict):
+                    # used for product testing
+                    if q.get('query'):
+                        test_query['or'].append(query_string(q.get('query')))
+                    if q.get('planning_item_query'):
+                        test_query['or'].append(planning_items_query_string(q.get('planning_item_query')))
+                    if test_query['or']:
+                        query['bool']['must'].append(test_query)
+            except Exception:
+                pass
+
+            if not test_query.get('or'):
+                query['bool']['must'].append(get_agenda_query(req.args['q']))
 
         if req.args.get('id'):
             query['bool']['must'].append({'term': {'_id': req.args['id']}})

--- a/newsroom/agenda/agenda.py
+++ b/newsroom/agenda/agenda.py
@@ -367,7 +367,7 @@ class AgendaService(newsroom.Service):
 
     def _enhance_items(self, docs):
         for doc in docs:
-            inner_hits = doc.pop('inner_hits', None)
+            inner_hits = doc.pop('_inner_hits', None)
             if not inner_hits or not inner_hits.get('planning_items'):
                 continue
 

--- a/newsroom/agenda/agenda.py
+++ b/newsroom/agenda/agenda.py
@@ -374,6 +374,7 @@ class AgendaService(newsroom.Service):
             items_by_key = {p.get('guid'): p for p in inner_hits.get('planning_items')}
             doc['planning_items'] = [p for p in doc['planning_items']
                                      if items_by_key.get(p.get('guid'))]
+            doc['coverages'] = [c for c in doc['coverages'] if items_by_key.get(c.get('planning_id'))]
 
     def get(self, req, lookup):
         query = _agenda_query()

--- a/newsroom/products/products.py
+++ b/newsroom/products/products.py
@@ -21,6 +21,9 @@ class ProductsResource(newsroom.Resource):
         'query': {
             'type': 'string'
         },
+        'planning_item_query': {
+            'type': 'string'
+        },
         'is_enabled': {
             'type': 'boolean',
             'default': True

--- a/newsroom/products/views.py
+++ b/newsroom/products/views.py
@@ -74,6 +74,7 @@ def edit(id):
         'description': data.get('description'),
         'sd_product_id': data.get('sd_product_id'),
         'query': data.get('query'),
+        'planning_item_query': data.get('planning_item_query'),
         'is_enabled': data.get('is_enabled'),
         'product_type': data.get('product_type', 'wire')
     }

--- a/newsroom/push.py
+++ b/newsroom/push.py
@@ -398,27 +398,18 @@ def get_display_dates(agenda_date, planning_items):
     """
     display_dates = []
 
-    def should_add(date):
-        try:
-            return not (agenda_date['start'].date() <= date.date() <= agenda_date['end'].date()) and \
-                   not date.date() in [d['date'].date() for d in display_dates]
-        except (AttributeError, TypeError):
-            return False
-
     for planning_item in planning_items:
         if not planning_item.get('coverages'):
             parsed_date = parse_date_str(planning_item['planning_date'])
-            if should_add(parsed_date):
-                display_dates.append({
-                    'date': parsed_date
-                })
+            display_dates.append({
+                'date': parsed_date
+            })
 
         for coverage in planning_item.get('coverages') or []:
             parsed_date = parse_date_str(coverage['planning']['scheduled'])
-            if should_add(parsed_date):
-                display_dates.append({
-                    'date': parsed_date
-                })
+            display_dates.append({
+                'date': parsed_date
+            })
 
     return display_dates
 

--- a/newsroom/utils.py
+++ b/newsroom/utils.py
@@ -70,10 +70,16 @@ def get_type():
     return types[item_type]
 
 
+def parse_date_str(date):
+    if date and isinstance(date, str):
+        return parse_date(date)
+    return date
+
+
 def parse_dates(item):
     for field in ['firstcreated', 'versioncreated', 'embargoed']:
-        if item.get(field) and type(item[field]) == str:
-            item[field] = parse_date(item[field])
+        if parse_date_str(item.get(field)):
+            item[field] = parse_date_str(item[field])
 
 
 def get_entity_dict(items):
@@ -114,3 +120,15 @@ def filter_active_users(user_ids, user_dict, company_dict):
         if user and (not user.get('company') or str(user.get('company', '')) in company_dict):
             active.append(_id)
     return active
+
+
+def unique_codes(key, *groups):
+    """Get unique items from all lists using code."""
+    codes = set()
+    items = []
+    for group in groups:
+        for item in group:
+            if item.get(key) and item[key] not in codes:
+                codes.add(item[key])
+                items.append(item)
+    return items

--- a/newsroom/wire/search.py
+++ b/newsroom/wire/search.py
@@ -104,6 +104,8 @@ def set_product_query(query, company, section, user=None, navigation_id=None):
                     raise FeaturedQuery
             else:
                 query['bool']['should'].append(query_string(product['query']))
+                if product.get('planning_item_query'):
+                    query['bool']['should'].append(planning_items_query_string(product.get('planning_item_query')))
 
     query['bool']['minimum_should_match'] = 1
 
@@ -123,6 +125,24 @@ def query_string(query):
             'query': query,
             'default_operator': 'AND',
             'lenient': True,
+        }
+    }
+
+
+def planning_items_query_string(query, fields=None):
+    query_string_syntax = query_string(query)
+
+    if fields:
+        query_string_syntax['query_string']['fields'] = fields
+    else:
+        query_string_syntax['query_string']['fields'] = ['planning_items.*']
+
+    return {
+        'nested': {
+            'path': 'planning_items',
+            'inner_hits': {
+            },
+            'query': query_string_syntax
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "karma-jasmine": "^1.1.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^2.0.4",
-    "react-gettext-parser": "^1.6.0",
+    "react-gettext-parser": "1.7.0",
     "react-test-renderer": "^16.0.0",
     "sinon": "^4.0.0"
   }

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup, find_packages
 install_requires = [
     'Babel>=2.5.3,<3.0',
     'eve==0.7.8',
+    'eve-elastic==2.5.0',
     'flask>=0.12,<1.0',
     'flask-babel>=0.11.2,<0.12',
     'flask-webpack>=0.1.0,<0.2',

--- a/tests/test_push_events.py
+++ b/tests/test_push_events.py
@@ -304,9 +304,11 @@ def test_push_coverages_with_different_dates_for_an_existing_event(client, app):
     assert 2 == len(parsed['coverages'])
     assert parsed['dates']['start'].isoformat() == event['dates']['start'].replace('0000', '00:00')
     assert parsed['dates']['end'].isoformat() == event['dates']['end'].replace('0000', '00:00')
-    assert 1 == len(parsed['display_dates'])
+    assert 2 == len(parsed['display_dates'])
     assert parsed['display_dates'][0]['date'].isoformat() == \
         planning['coverages'][0]['planning']['scheduled'].replace('0000', '00:00')
+    assert parsed['display_dates'][1]['date'].isoformat() == \
+        planning['coverages'][1]['planning']['scheduled'].replace('0000', '00:00')
 
 
 def test_push_planning_with_different_dates_for_an_existing_event(client, app):

--- a/tests/test_push_events.py
+++ b/tests/test_push_events.py
@@ -250,19 +250,30 @@ def test_push_parsed_planning_for_an_existing_event(client, app):
     planning['event_item'] = 'foo4'
     client.post('/push', data=json.dumps(planning), content_type='application/json')
     parsed = get_entity_or_404('foo4', 'agenda')
-    assert parsed['headline'] == 'Planning headline'
-    assert 2 == len(parsed['coverages'])
-    assert 2 == len(parsed['service'])
-    assert 'e' == parsed['service'][0]['code']
-    assert 'a' == parsed['service'][1]['code']
-    assert 2 == len(parsed['subject'])
-    assert '06002002' == parsed['subject'][0]['code']
-    assert '01009000' == parsed['subject'][1]['code']
     assert parsed['name'] == test_event['name']
     assert parsed['definition_short'] == test_event['definition_short']
+    assert parsed['slugline'] == test_event['slugline']
     assert parsed['definition_long'] == test_event['definition_long']
     assert parsed['dates']['start'].isoformat() == test_event['dates']['start'].replace('0000', '00:00')
     assert parsed['dates']['end'].isoformat() == test_event['dates']['end'].replace('0000', '00:00')
+    assert parsed['ednote'] == event['ednote']
+
+    assert 2 == len(parsed['coverages'])
+    assert 1 == len(parsed['service'])
+    assert 'a' == parsed['service'][0]['code']
+    assert 1 == len(parsed['subject'])
+    assert '06002002' == parsed['subject'][0]['code']
+
+    parsed_planning = parsed['planning_items'][0]
+    assert 1 == len(parsed_planning['service'])
+    assert 'e' == parsed_planning['service'][0]['code']
+    assert 1 == len(parsed_planning['subject'])
+    assert '01009000' == parsed_planning['subject'][0]['code']
+    assert parsed_planning['description_text'] == planning['description_text']
+    assert parsed_planning['slugline'] == planning['slugline']
+    assert parsed_planning['headline'] == planning['headline']
+    assert parsed_planning['ednote'] == planning['ednote']
+    assert 2 == len(parsed_planning['coverages'])
 
 
 def test_push_coverages_with_different_dates_for_an_existing_event(client, app):
@@ -283,9 +294,14 @@ def test_push_coverages_with_different_dates_for_an_existing_event(client, app):
     # planning['planning_date'] = "2018-05-28T10:51:52+0000"
     client.post('/push', data=json.dumps(planning), content_type='application/json')
     parsed = get_entity_or_404('foo4', 'agenda')
-    assert parsed['headline'] == 'Planning headline'
-    assert 2 == len(parsed['coverages'])
     assert parsed['name'] == test_event['name']
+    assert parsed['definition_short'] == test_event['definition_short']
+    assert parsed['slugline'] == test_event['slugline']
+
+    parsed_planning = parsed['planning_items'][0]
+    assert parsed_planning['description_text'] == planning['description_text']
+
+    assert 2 == len(parsed['coverages'])
     assert parsed['dates']['start'].isoformat() == event['dates']['start'].replace('0000', '00:00')
     assert parsed['dates']['end'].isoformat() == event['dates']['end'].replace('0000', '00:00')
     assert 1 == len(parsed['display_dates'])
@@ -311,12 +327,17 @@ def test_push_planning_with_different_dates_for_an_existing_event(client, app):
     planning['planning_date'] = "2018-07-28T10:51:52+0000"
     client.post('/push', data=json.dumps(planning), content_type='application/json')
     parsed = get_entity_or_404('foo4', 'agenda')
-    assert parsed['headline'] == 'Planning headline'
     assert parsed['name'] == test_event['name']
+    assert parsed['definition_short'] == test_event['definition_short']
+    assert parsed['slugline'] == test_event['slugline']
     assert parsed['dates']['start'].isoformat() == event['dates']['start'].replace('0000', '00:00')
     assert parsed['dates']['end'].isoformat() == event['dates']['end'].replace('0000', '00:00')
     assert 1 == len(parsed['display_dates'])
     assert parsed['display_dates'][0]['date'].isoformat() == planning['planning_date'].replace('0000', '00:00')
+
+    parsed_planning = parsed['planning_items'][0]
+    assert parsed_planning['description_text'] == planning['description_text']
+    assert parsed_planning['slugline'] == planning['slugline']
 
 
 def test_push_cancelled_planning_for_an_existing_event(client, app):
@@ -366,7 +387,7 @@ def test_push_parsed_adhoc_planning_for_an_non_existing_event(client, app):
     assert 1 == len(parsed['planning_items'])
     assert parsed['headline'] == 'Planning headline'
     assert parsed['definition_short'] == test_planning['description_text']
-    assert parsed['abstract'] == test_planning['abstract']
+    assert parsed['definition_long'] == test_planning['abstract']
 
 
 def test_notify_topic_matches_for_new_event_item(client, app, mocker):
@@ -1017,7 +1038,6 @@ def test_push_coverages_with_linked_stories(client, app):
 
     client.post('/push', data=json.dumps(planning), content_type='application/json')
     parsed = get_entity_or_404('foo7', 'agenda')
-    assert parsed['headline'] == 'Planning headline'
     assert 2 == len(parsed['coverages'])
     assert parsed['coverages'][0]['delivery_id'] == 'item7'
     assert parsed['coverages'][0]['delivery_href'] == '/wire/item7'


### PR DESCRIPTION
- Using nested planning items to apply filter on planning items
- Displaying tiles based on coverage dates and showing similar information in preview and item details
- Fixing keyboard scroll
- Merging event with adhoc planning item (when event is posted after planning item is posted) 
