### PR TITLE
[SDAN-420] Tests for 'AM News' and 'aapX' blueprints

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 flake8
 sphinx
 sphinx-autobuild
-pytest
+pytest==3.10.0
 pytest-cov
 pytest-mock

--- a/newsroom/market_place/views.py
+++ b/newsroom/market_place/views.py
@@ -126,7 +126,7 @@ def versions(_id):
 @login_required
 def item(_id):
     item = get_entity_or_404(_id, 'items')
-    set_permissions(item)
+    set_permissions(item, 'aapX')
     display_char_count = get_resource_service('ui_config').getSectionConfig(SECTION_ID).get('char_count', False)
     if is_json_request(flask.request):
         return flask.jsonify(item)

--- a/tests/aap/conftest.py
+++ b/tests/aap/conftest.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+from pytest import fixture
+
+from tests.conftest import update_config, client, setup  # noqa
+
+root = (Path(__file__).parent / '..').resolve()
+sys.path.insert(0, str(root))
+
+
+@fixture
+def app():
+    from flask import Config
+    from newsroom import Newsroom
+
+    cfg = Config(root)
+    cfg.from_object('newsroom.default_settings')
+    cfg.from_object('tests.aap.settings')
+    update_config(cfg)
+    return Newsroom(config=cfg, testing=True)

--- a/tests/aap/settings.py
+++ b/tests/aap/settings.py
@@ -1,0 +1,19 @@
+from newsroom.default_settings import BLUEPRINTS, CLIENT_CONFIG
+
+BLUEPRINTS.append('newsroom.am_news')
+BLUEPRINTS.append('newsroom.market_place')
+
+INSTALLED_APPS = [
+    'newsroom.am_news',
+    'newsroom.market_place',
+]
+
+CLIENT_TIME_FORMAT = 'HH:mm'
+CLIENT_DATE_FORMAT = 'DD/MM/YYYY'
+SITE_NAME = 'AAP Newsroom'
+COPYRIGHT_HOLDER = 'AAP'
+COPYRIGHT_NOTICE = ''
+USAGE_TERMS = ''
+LANGUAGES = ['en']
+DEFAULT_LANGUAGE = 'en'
+CLIENT_CONFIG['list_animations'] = False

--- a/tests/aap/test_am_news.py
+++ b/tests/aap/test_am_news.py
@@ -1,0 +1,353 @@
+from tests.fixtures import items, init_items, init_auth, init_company, PUBLIC_USER_ID  # noqa
+from tests.utils import json, get_json
+
+from flask import g
+from bson import ObjectId
+from datetime import datetime, timedelta
+
+
+def test_blueprint_registration(client):
+    resp = client.get('/am_news')
+    assert resp.status_code == 200
+
+
+def test_item_detail(client):
+    resp = client.get('/am_news/tag:foo')
+    assert resp.status_code == 200
+
+    html = resp.get_data().decode('utf-8')
+    assert 'Amazon Is Opening More Bookstores' in html
+
+
+def test_item_json(client):
+    resp = client.get('/am_news/tag:foo?format=json')
+    assert resp.status_code == 200
+
+    data = json.loads(resp.get_data())
+    assert 'headline' in data
+    assert data['headline'] == 'Amazon Is Opening More Bookstores'
+
+
+def get_bookmarks_count(client, user):
+    resp = client.get('/api/am_news_search?bookmarks=%s' % str(user))
+    assert resp.status_code == 200
+    data = json.loads(resp.get_data())
+    return data['_meta']['total']
+
+
+def test_bookmarks(client, app):
+    user_id = app.data.find_all('users')[0]['_id']
+    assert user_id
+
+    assert 0 == get_bookmarks_count(client, user_id)
+
+    resp = client.post('/am_news_bookmark', data=json.dumps({
+        'items': [items[0]['_id']],
+    }), content_type='application/json')
+    assert resp.status_code == 200
+
+    assert 1 == get_bookmarks_count(client, user_id)
+
+    client.delete('/am_news_bookmark', data=json.dumps({
+        'items': [items[0]['_id']],
+    }), content_type='application/json')
+    assert resp.status_code == 200
+
+    assert 0 == get_bookmarks_count(client, user_id)
+
+
+def test_bookmarks_by_section(client, app):
+    products = [
+        {
+            "_id": 1,
+            "name": "Service A",
+            "query": "service.code: a",
+            "is_enabled": True,
+            "description": "Service A",
+            "companies": ['1'],
+            "sd_product_id": None,
+            "product_type": "am_news"
+        }
+    ]
+
+    app.data.insert('products', products)
+    product_id = app.data.find_all('products')[0]['_id']
+    assert product_id == 1
+
+    with client.session_transaction() as session:
+        session['user'] = str(PUBLIC_USER_ID)
+        session['user_type'] = 'public'
+        session['name'] = 'public'
+
+    assert 0 == get_bookmarks_count(client, PUBLIC_USER_ID)
+
+    resp = client.post('/wire_bookmark', data=json.dumps({
+        'items': [items[0]['_id']],
+    }), content_type='application/json')
+    assert resp.status_code == 200
+
+    assert 1 == get_bookmarks_count(client, PUBLIC_USER_ID)
+
+    client.delete('/wire_bookmark', data=json.dumps({
+        'items': [items[0]['_id']],
+    }), content_type='application/json')
+    assert resp.status_code == 200
+
+    assert 0 == get_bookmarks_count(client, PUBLIC_USER_ID)
+
+
+def test_item_copy(client, app):
+    resp = client.post(
+        '/am_news/{}/copy'.format(items[0]['_id']),
+        content_type='application/json'
+    )
+    assert resp.status_code == 200
+
+    resp = client.get('/am_news/tag:foo?format=json')
+    data = json.loads(resp.get_data())
+    assert 'copies' in data
+
+    user_id = app.data.find_all('users')[0]['_id']
+    assert str(user_id) in data['copies']
+
+
+def test_versions(client):
+    resp = client.get('/am_news/%s/versions' % items[0]['_id'])
+    assert 200 == resp.status_code
+    data = json.loads(resp.get_data())
+    assert len(data.get('_items')) == 0
+
+    resp = client.get('/am_news/%s/versions' % items[1]['_id'])
+    data = json.loads(resp.get_data())
+    assert 2 == len(data['_items'])
+    assert 'tag:weather' == data['_items'][0]['_id']
+    assert 'AAP' == data['_items'][0]['source']
+    assert 'c' == data['_items'][1]['service'][0]['code']
+
+
+def test_search_by_products_id(client, app):
+    app.data.insert('items', [
+        {'_id': 'foo', 'headline': 'product test', 'products': [{'code': '12345'}]}
+    ])
+    resp = client.get('/am_news/search?q=products.code:12345')
+    data = json.loads(resp.get_data())
+    assert 1 == len(data['_items'])
+
+
+def test_filter_by_product_anonymous_user_gets_all(client):
+    resp = client.get('/am_news/search?products=%s' % json.dumps({'10': True}))
+    data = json.loads(resp.get_data())
+    assert 3 == len(data['_items'])
+    assert '_aggregations' in data
+
+
+def test_logged_in_user_no_product_gets_no_results(client):
+    with client.session_transaction() as session:
+        session['user'] = str(PUBLIC_USER_ID)
+        session['user_type'] = 'public'
+    resp = client.get('/am_news/search')
+    assert 403 == resp.status_code
+
+
+def test_logged_in_user_no_company_gets_no_results(client):
+    with client.session_transaction() as session:
+        session['user'] = str(ObjectId())
+        session['user_type'] = 'public'
+
+    resp = client.get('/am_news/search')
+    assert resp.status_code == 403
+
+
+def test_administrator_gets_all_results(client):
+    with client.session_transaction() as session:
+        session['user'] = str(ObjectId())
+        session['user_type'] = 'administrator'
+
+    resp = client.get('/am_news/search')
+    data = json.loads(resp.get_data())
+    assert 3 == len(data['_items'])
+
+
+def test_search_filtered_by_users_products(client, app):
+    app.data.insert('products', [{
+        '_id': 10,
+        'name': 'product test',
+        'sd_product_id': 1,
+        'companies': ['1'],
+        'is_enabled': True,
+        'product_type': 'am_news'
+    }])
+
+    with client.session_transaction() as session:
+        session['user'] = str(PUBLIC_USER_ID)
+        session['user_type'] = 'public'
+
+    resp = client.get('/am_news/search')
+    data = json.loads(resp.get_data())
+    assert 1 == len(data['_items'])
+    assert '_aggregations' in data
+
+
+def test_search_pagination(client):
+    resp = client.get('/am_news/search?from=25')
+    assert 200 == resp.status_code
+    data = json.loads(resp.get_data())
+    assert 0 == len(data['_items'])
+    assert '_aggregations' not in data
+
+    resp = client.get('/am_news/search?from=2000')
+    assert 400 == resp.status_code
+
+
+def test_search_created_from(client):
+    resp = client.get('/am_news/search?created_from=now/d')
+    data = json.loads(resp.get_data())
+    assert 1 == len(data['_items'])
+
+    resp = client.get('/am_news/search?created_from=now/w')
+    data = json.loads(resp.get_data())
+    assert 1 <= len(data['_items'])
+
+    resp = client.get('/am_news/search?created_from=now/M')
+    data = json.loads(resp.get_data())
+
+    assert 1 <= len(data['_items'])
+
+
+def test_search_created_to(client):
+    resp = client.get('/am_news/search?created_to=%s' % datetime.now().strftime('%Y-%m-%d'))
+    data = json.loads(resp.get_data())
+    assert 3 == len(data['_items'])
+
+    resp = client.get('/am_news/search?created_to=%s&timezone_offset=%s' % (
+        (datetime.now() - timedelta(days=5)).strftime('%Y-%m-%d'),
+        -120
+    ))
+    data = json.loads(resp.get_data())
+    assert 0 == len(data['_items'])
+
+
+def test_item_detail_access(client, app):
+    item_url = '/am_news/%s' % items[0]['_id']
+    data = get_json(client, item_url)
+    assert data['_access']
+    assert data['body_html']
+
+    # public user
+    with client.session_transaction() as session:
+        session['user'] = str(PUBLIC_USER_ID)
+        session['user_type'] = 'public'
+
+    # no access by default
+    data = get_json(client, item_url)
+    assert not data['_access']
+    assert not data.get('body_html')
+
+    # add product
+    app.data.insert('products', [{
+        '_id': 10,
+        'name': 'matching product',
+        'companies': ['1'],
+        'is_enabled': True,
+        'product_type': 'am_news',
+        'query': 'slugline:%s' % items[0]['slugline']
+    }])
+
+    # normal access
+    data = get_json(client, item_url)
+    assert data['_access']
+    assert data['body_html']
+
+
+def test_administrator_gets_results_based_on_section_filter(client, app):
+    with client.session_transaction() as session:
+        session['user'] = str(ObjectId())
+        session['user_type'] = 'administrator'
+
+    app.data.insert('section_filters', [{
+        '_id': 'f-1',
+        'name': 'product test 2',
+        'query': 'headline:Weather',
+        'is_enabled': True,
+        'filter_type': 'am_news'
+    }])
+
+    resp = client.get('/am_news/search')
+    data = json.loads(resp.get_data())
+    assert 1 == len(data['_items'])
+
+
+def test_time_limited_access(client, app):
+    app.data.insert('products', [{
+        '_id': 10,
+        'name': 'product test',
+        'query': 'versioncreated:<=now-2d',
+        'companies': ['1'],
+        'is_enabled': True,
+        'product_type': 'am_news'
+    }])
+
+    with client.session_transaction() as session:
+        session['user'] = str(PUBLIC_USER_ID)
+        session['user_type'] = 'public'
+
+    resp = client.get('/am_news/search')
+    data = json.loads(resp.get_data())
+    assert 2 == len(data['_items'])
+
+    g.settings['wire_time_limit_days']['value'] = 1
+    resp = client.get('/am_news/search')
+    data = json.loads(resp.get_data())
+    assert 0 == len(data['_items'])
+
+    g.settings['wire_time_limit_days']['value'] = 100
+    resp = client.get('/am_news/search')
+    data = json.loads(resp.get_data())
+    assert 2 == len(data['_items'])
+
+    g.settings['wire_time_limit_days']['value'] = 1
+    company = app.data.find_one('companies', req=None, _id=1)
+    app.data.update('companies', 1, {'archive_access': True}, company)
+    resp = client.get('/am_news/search')
+    data = json.loads(resp.get_data())
+    assert 2 == len(data['_items'])
+
+
+def test_company_type_filter(client, app):
+    app.data.insert('products', [{
+        '_id': 10,
+        'name': 'product test',
+        'query': 'versioncreated:<=now-2d',
+        'companies': ['1'],
+        'is_enabled': True,
+        'product_type': 'am_news'
+    }])
+
+    with client.session_transaction() as session:
+        session['user'] = str(PUBLIC_USER_ID)
+        session['user_type'] = 'public'
+
+    resp = client.get('/am_news/search')
+    data = json.loads(resp.get_data())
+    assert 2 == len(data['_items'])
+
+    app.config['COMPANY_TYPES'] = [
+        dict(id='test', wire_must={'term': {'service.code': 'b'}}),
+    ]
+
+    company = app.data.find_one('companies', req=None, _id=1)
+    app.data.update('companies', 1, {'company_type': 'test'}, company)
+
+    resp = client.get('/am_news/search')
+    data = json.loads(resp.get_data())
+    assert 1 == len(data['_items'])
+    assert 'WEATHER' == data['_items'][0]['slugline']
+
+    app.config['COMPANY_TYPES'] = [
+        dict(id='test', wire_must_not={'term': {'service.code': 'b'}}),
+    ]
+
+    resp = client.get('/am_news/search')
+    data = json.loads(resp.get_data())
+    assert 1 == len(data['_items'])
+    assert 'WEATHER' != data['_items'][0]['slugline']

--- a/tests/aap/test_market_place.py
+++ b/tests/aap/test_market_place.py
@@ -1,0 +1,530 @@
+from tests.fixtures import items, init_items, init_auth, init_company, PUBLIC_USER_ID  # noqa
+from tests.utils import json, get_json
+
+from flask import g
+from bson import ObjectId
+from datetime import datetime, timedelta
+
+
+def test_blueprint_registration(client):
+    resp = client.get('/aapX')
+    assert resp.status_code == 200
+
+
+def test_item_detail(client):
+    resp = client.get('/aapX/tag:foo')
+    assert resp.status_code == 200
+    html = resp.get_data().decode('utf-8')
+    assert 'Amazon Is Opening More Bookstores' in html
+
+
+def test_item_json(client):
+    resp = client.get('/aapX/tag:foo?format=json')
+    data = json.loads(resp.get_data())
+    assert 'headline' in data
+
+
+def get_bookmarks_count(client, user):
+    resp = client.get('/api/aapX_search?bookmarks=%s' % str(user))
+    assert resp.status_code == 200
+    data = json.loads(resp.get_data())
+    return data['_meta']['total']
+
+
+def test_bookmarks(client, app):
+    user_id = app.data.find_all('users')[0]['_id']
+    assert user_id
+
+    assert 0 == get_bookmarks_count(client, user_id)
+
+    resp = client.post('/aapX_bookmark', data=json.dumps({
+        'items': [items[0]['_id']],
+    }), content_type='application/json')
+    assert resp.status_code == 200
+
+    assert 1 == get_bookmarks_count(client, user_id)
+
+    client.delete('/aapX_bookmark', data=json.dumps({
+        'items': [items[0]['_id']],
+    }), content_type='application/json')
+    assert resp.status_code == 200
+
+    assert 0 == get_bookmarks_count(client, user_id)
+
+
+def test_bookmarks_by_section(client, app):
+    products = [
+        {
+            "_id": 1,
+            "name": "Service A",
+            "query": "service.code: a",
+            "is_enabled": True,
+            "description": "Service A",
+            "companies": ['1'],
+            "sd_product_id": None,
+            "product_type": "aapX"
+        }
+    ]
+
+    app.data.insert('products', products)
+    product_id = app.data.find_all('products')[0]['_id']
+    assert product_id == 1
+
+    with client.session_transaction() as session:
+        session['user'] = str(PUBLIC_USER_ID)
+        session['user_type'] = 'public'
+
+    assert 0 == get_bookmarks_count(client, PUBLIC_USER_ID)
+
+    resp = client.post('/aapX_bookmark', data=json.dumps({
+        'items': [items[0]['_id']],
+    }), content_type='application/json')
+    assert resp.status_code == 200
+
+    assert 1 == get_bookmarks_count(client, PUBLIC_USER_ID)
+
+    client.delete('/aapX_bookmark', data=json.dumps({
+        'items': [items[0]['_id']],
+    }), content_type='application/json')
+    assert resp.status_code == 200
+
+    assert 0 == get_bookmarks_count(client, PUBLIC_USER_ID)
+
+
+def test_item_copy(client, app):
+    resp = client.post('/aapX/{}/copy'.format(items[0]['_id']), content_type='application/json')
+    assert resp.status_code == 200
+
+    resp = client.get('/aapX/tag:foo?format=json')
+    data = json.loads(resp.get_data())
+    assert 'copies' in data
+
+    user_id = app.data.find_all('users')[0]['_id']
+    assert str(user_id) in data['copies']
+
+
+def test_versions(client, app):
+    resp = client.get('/aapX/%s/versions' % items[0]['_id'])
+    assert 200 == resp.status_code
+    data = json.loads(resp.get_data())
+    assert len(data.get('_items')) == 0
+
+    resp = client.get('/aapX/%s/versions' % items[1]['_id'])
+    data = json.loads(resp.get_data())
+    assert 2 == len(data['_items'])
+    assert 'tag:weather' == data['_items'][0]['_id']
+    assert 'AAP' == data['_items'][0]['source']
+    assert 'c' == data['_items'][1]['service'][0]['code']
+
+
+def test_search_filters_items_with_updates(client, app):
+    resp = client.get('/aapX/search')
+    data = json.loads(resp.get_data())
+    assert 3 == len(data['_items'])
+    assert 'tag:weather' not in [item['_id'] for item in data['_items']]
+
+
+def test_search_includes_killed_items(client, app):
+    app.data.insert('items', [{'_id': 'foo', 'pubstatus': 'canceled', 'headline': 'killed'}])
+    resp = client.get('/aapX/search?q=headline:killed')
+    data = json.loads(resp.get_data())
+    assert 1 == len(data['_items'])
+
+
+def test_search_by_products_id(client, app):
+    app.data.insert('items', [{'_id': 'foo', 'headline': 'product test', 'products': [{'code': '12345'}]}])
+    resp = client.get('/aapX/search?q=products.code:12345')
+    data = json.loads(resp.get_data())
+    assert 1 == len(data['_items'])
+
+
+def test_search_filter_by_category(client, app):
+    resp = client.get('/aapX/search?filter=%s' % json.dumps({'service': ['Service A']}))
+    data = json.loads(resp.get_data())
+    assert 1 == len(data['_items'])
+
+
+def test_filter_by_product_anonymous_user_gets_all(client, app):
+    resp = client.get('/aapX/search?products=%s' % json.dumps({'10': True}))
+    data = json.loads(resp.get_data())
+    assert 3 == len(data['_items'])
+    assert '_aggregations' in data
+
+
+def test_logged_in_user_no_product_gets_no_results(client, app):
+    with client.session_transaction() as session:
+        session['user'] = str(PUBLIC_USER_ID)
+        session['user_type'] = 'public'
+    resp = client.get('/aapX/search')
+    assert 403 == resp.status_code
+
+
+def test_logged_in_user_no_company_gets_no_results(client, app):
+    with client.session_transaction() as session:
+        session['user'] = str(ObjectId())
+        session['user_type'] = 'public'
+
+    resp = client.get('/aapX/search')
+    assert resp.status_code == 403
+
+
+def test_administrator_gets_all_results(client, app):
+    with client.session_transaction() as session:
+        session['user'] = str(ObjectId())
+        session['user_type'] = 'administrator'
+
+    resp = client.get('/aapX/search')
+    data = json.loads(resp.get_data())
+    assert 3 == len(data['_items'])
+
+
+def test_search_filtered_by_users_products(client, app):
+    app.data.insert('products', [{
+        '_id': 10,
+        'name': 'product test',
+        'sd_product_id': 1,
+        'companies': ['1'],
+        'is_enabled': True,
+        'product_type': 'aapX'
+    }])
+
+    with client.session_transaction() as session:
+        session['user'] = str(PUBLIC_USER_ID)
+        session['user_type'] = 'public'
+
+    resp = client.get('/aapX/search')
+    data = json.loads(resp.get_data())
+    assert 1 == len(data['_items'])
+    assert '_aggregations' in data
+
+
+def test_search_filter_by_individual_navigation(client, app):
+    app.data.insert('navigations', [{
+        '_id': 51,
+        'name': 'navigation-1',
+        'is_enabled': True,
+        'product_type': 'aapX'
+    }, {
+        '_id': 52,
+        'name': 'navigation-2',
+        'is_enabled': True,
+        'product_type': 'aapX'
+    }])
+
+    app.data.insert('products', [{
+        '_id': 10,
+        'name': 'product test',
+        'sd_product_id': 1,
+        'companies': ['1'],
+        'navigations': ['51'],
+        'product_type': 'aapX',
+        'is_enabled': True
+    }, {
+        '_id': 11,
+        'name': 'product test 2',
+        'sd_product_id': 2,
+        'companies': ['1'],
+        'navigations': ['52'],
+        'product_type': 'aapX',
+        'is_enabled': True
+    }])
+    with client.session_transaction() as session:
+        session['user'] = str(PUBLIC_USER_ID)
+        session['user_type'] = 'public'
+
+    resp = client.get('/aapX/search')
+    data = json.loads(resp.get_data())
+    assert 2 == len(data['_items'])
+    assert '_aggregations' in data
+    resp = client.get('/aapX/search?navigation=51')
+    data = json.loads(resp.get_data())
+    assert 1 == len(data['_items'])
+    assert '_aggregations' in data
+
+    # test admin user filtering
+    with client.session_transaction() as session:
+        session['user_type'] = 'administrator'
+
+    resp = client.get('/aapX/search')
+    data = json.loads(resp.get_data())
+    assert 3 == len(data['_items'])  # gets all by default
+
+    resp = client.get('/aapX/search?navigation=51')
+    data = json.loads(resp.get_data())
+    assert 1 == len(data['_items'])
+
+
+def test_search_filtered_by_query_product(client, app):
+    app.data.insert('navigations', [{
+        '_id': 51,
+        'name': 'navigation-1',
+        'is_enabled': True,
+        'product_type': 'aapX',
+    }, {
+        '_id': 52,
+        'name': 'navigation-2',
+        'is_enabled': True,
+        'product_type': 'aapX'
+    }])
+
+    app.data.insert('products', [{
+        '_id': 12,
+        'name': 'product test',
+        'query': 'headline:more',
+        'companies': ['1'],
+        'navigations': ['51'],
+        'product_type': 'aapX',
+        'is_enabled': True
+    }, {
+        '_id': 13,
+        'name': 'product test 2',
+        'query': 'headline:Weather',
+        'companies': ['1'],
+        'navigations': ['52'],
+        'product_type': 'aapX',
+        'is_enabled': True
+    }])
+
+    with client.session_transaction() as session:
+        session['user'] = str(PUBLIC_USER_ID)
+        session['user_type'] = 'public'
+
+    resp = client.get('/aapX/search')
+    data = json.loads(resp.get_data())
+    assert 2 == len(data['_items'])
+    assert '_aggregations' in data
+    resp = client.get('/aapX/search?navigation=52')
+    data = json.loads(resp.get_data())
+    assert 1 == len(data['_items'])
+    assert '_aggregations' in data
+
+
+def test_search_pagination(client):
+    resp = client.get('/aapX/search?from=25')
+    assert 200 == resp.status_code
+    data = json.loads(resp.get_data())
+    assert 0 == len(data['_items'])
+    assert '_aggregations' not in data
+
+    resp = client.get('/aapX/search?from=2000')
+    assert 400 == resp.status_code
+
+
+def test_search_created_from(client):
+    resp = client.get('/aapX/search?created_from=now/d')
+    data = json.loads(resp.get_data())
+    assert 1 == len(data['_items'])
+
+    resp = client.get('/aapX/search?created_from=now/w')
+    data = json.loads(resp.get_data())
+    assert 1 <= len(data['_items'])
+
+    resp = client.get('/aapX/search?created_from=now/M')
+    data = json.loads(resp.get_data())
+
+    assert 1 <= len(data['_items'])
+
+
+def test_search_created_to(client):
+    resp = client.get('/aapX/search?created_to=%s' % datetime.now().strftime('%Y-%m-%d'))
+    data = json.loads(resp.get_data())
+    assert 3 == len(data['_items'])
+
+    resp = client.get('/aapX/search?created_to=%s&timezone_offset=%s' % (
+        (datetime.now() - timedelta(days=5)).strftime('%Y-%m-%d'),
+        -120
+    ))
+    data = json.loads(resp.get_data())
+    assert 0 == len(data['_items'])
+
+
+def test_item_detail_access(client, app):
+    item_url = '/aapX/%s' % items[0]['_id']
+    data = get_json(client, item_url)
+    assert data['_access']
+    assert data['body_html']
+
+    # public user
+    with client.session_transaction() as session:
+        session['user'] = PUBLIC_USER_ID
+        session['user_type'] = 'public'
+
+    # no access by default
+    data = get_json(client, item_url)
+    assert not data['_access']
+    assert not data.get('body_html')
+
+    # add product
+    app.data.insert('products', [{
+        '_id': 10,
+        'name': 'matching product',
+        'companies': ['1'],
+        'is_enabled': True,
+        'product_type': 'aapX',
+        'query': 'slugline:%s' % items[0]['slugline']
+    }])
+
+    # normal access
+    data = get_json(client, item_url)
+    assert data['_access']
+    assert data['body_html']
+
+
+def test_search_using_section_filter_for_public_user(client, app):
+    app.data.insert('navigations', [{
+        '_id': 51,
+        'name': 'navigation-1',
+        'is_enabled': True,
+        'product_type': 'aapX'
+    }, {
+        '_id': 52,
+        'name': 'navigation-2',
+        'is_enabled': True,
+        'product_type': 'aapX'
+    }])
+
+    app.data.insert('products', [{
+        '_id': 12,
+        'name': 'product test',
+        'query': 'headline:more',
+        'companies': ['1'],
+        'navigations': ['51'],
+        'is_enabled': True,
+        'product_type': 'aapX'
+    }, {
+        '_id': 13,
+        'name': 'product test 2',
+        'query': 'headline:Weather',
+        'companies': ['1'],
+        'navigations': ['52'],
+        'is_enabled': True,
+        'product_type': 'aapX'
+    }])
+
+    with client.session_transaction() as session:
+        session['user'] = str(PUBLIC_USER_ID)
+        session['user_type'] = 'public'
+
+    resp = client.get('/aapX/search')
+    data = json.loads(resp.get_data())
+    assert 2 == len(data['_items'])
+    assert '_aggregations' in data
+    resp = client.get('/aapX/search?navigation=52')
+    data = json.loads(resp.get_data())
+    assert 1 == len(data['_items'])
+    assert '_aggregations' in data
+
+    app.data.insert('section_filters', [{
+        '_id': 'f-1',
+        'name': 'product test 2',
+        'query': 'headline:Weather',
+        'is_enabled': True,
+        'filter_type': 'aapX'
+    }])
+
+    resp = client.get('/aapX/search')
+    data = json.loads(resp.get_data())
+    assert 1 == len(data['_items'])
+
+    resp = client.get('/aapX/search?navigation=52')
+    data = json.loads(resp.get_data())
+    assert 1 == len(data['_items'])
+
+    resp = client.get('/aapX/search?navigation=51')
+    data = json.loads(resp.get_data())
+    assert 0 == len(data['_items'])
+
+
+def test_administrator_gets_results_based_on_section_filter(client, app):
+    with client.session_transaction() as session:
+        session['user'] = str(ObjectId())
+        session['user_type'] = 'administrator'
+
+    app.data.insert('section_filters', [{
+        '_id': 'f-1',
+        'name': 'product test 2',
+        'query': 'headline:Weather',
+        'is_enabled': True,
+        'filter_type': 'aapX'
+    }])
+
+    resp = client.get('/aapX/search')
+    data = json.loads(resp.get_data())
+    assert 1 == len(data['_items'])
+
+
+def test_time_limited_access(client, app):
+    app.data.insert('products', [{
+        '_id': 10,
+        'name': 'product test',
+        'query': 'versioncreated:<=now-2d',
+        'companies': ['1'],
+        'is_enabled': True,
+        'product_type': 'aapX'
+    }])
+
+    with client.session_transaction() as session:
+        session['user'] = str(PUBLIC_USER_ID)
+        session['user_type'] = 'public'
+
+    resp = client.get('/aapX/search')
+    data = json.loads(resp.get_data())
+    assert 2 == len(data['_items'])
+    print(data['_items'][0]['versioncreated'])
+
+    g.settings['wire_time_limit_days']['value'] = 1
+    resp = client.get('/aapX/search')
+    data = json.loads(resp.get_data())
+    assert 0 == len(data['_items'])
+
+    g.settings['wire_time_limit_days']['value'] = 100
+    resp = client.get('/aapX/search')
+    data = json.loads(resp.get_data())
+    assert 2 == len(data['_items'])
+
+    g.settings['wire_time_limit_days']['value'] = 1
+    company = app.data.find_one('companies', req=None, _id=1)
+    app.data.update('companies', 1, {'archive_access': True}, company)
+    resp = client.get('/aapX/search')
+    data = json.loads(resp.get_data())
+    assert 2 == len(data['_items'])
+
+
+def test_company_type_filter(client, app):
+    app.data.insert('products', [{
+        '_id': 10,
+        'name': 'product test',
+        'query': 'versioncreated:<=now-2d',
+        'companies': ['1'],
+        'is_enabled': True,
+        'product_type': 'aapX'
+    }])
+
+    with client.session_transaction() as session:
+        session['user'] = str(PUBLIC_USER_ID)
+        session['user_type'] = 'public'
+
+    resp = client.get('/aapX/search')
+    data = json.loads(resp.get_data())
+    assert 2 == len(data['_items'])
+
+    app.config['COMPANY_TYPES'] = [
+        dict(id='test', wire_must={'term': {'service.code': 'b'}}),
+    ]
+
+    company = app.data.find_one('companies', req=None, _id=1)
+    app.data.update('companies', 1, {'company_type': 'test'}, company)
+
+    resp = client.get('/aapX/search')
+    data = json.loads(resp.get_data())
+    assert 1 == len(data['_items'])
+    assert 'WEATHER' == data['_items'][0]['slugline']
+
+    app.config['COMPANY_TYPES'] = [
+        dict(id='test', wire_must_not={'term': {'service.code': 'b'}}),
+    ]
+
+    resp = client.get('/aapX/search')
+    data = json.loads(resp.get_data())
+    assert 1 == len(data['_items'])
+    assert 'WEATHER' != data['_items'][0]['slugline']


### PR DESCRIPTION
* Limit pytest to 3.10.0 (calling fixtures directly is deprecated and removed in 4.0.0)