### PR TITLE
[SDAN-430] Point url to section in history/bookmark notification emails

### DIFF
--- a/newsroom/email.py
+++ b/newsroom/email.py
@@ -153,14 +153,14 @@ def _send_new_agenda_notification_email(user, topic_name, item):
     send_email(to=recipients, subject=subject, text_body=text_body, html_body=html_body)
 
 
-def send_history_match_notification_email(user, item):
+def send_history_match_notification_email(user, item, section):
     if item.get('type') == 'text':
-        _send_history_match_wire_notification_email(user, item)
+        _send_history_match_wire_notification_email(user, item, section)
     else:
         _send_history_match_agenda_notification_email(user, item)
 
 
-def _send_history_match_wire_notification_email(user, item):
+def _send_history_match_wire_notification_email(user, item, section):
     app_name = current_app.config['SITE_NAME']
     url = url_for('wire.item', _id=item['guid'], _external=True)
     recipients = [user['email']]
@@ -173,7 +173,7 @@ def _send_history_match_wire_notification_email(user, item):
         item=item,
         url=url,
         type='wire',
-        section='wire'
+        section=section
     )
 
     send_email(to=recipients, subject=subject, text_body=text_body)

--- a/newsroom/history.py
+++ b/newsroom/history.py
@@ -12,13 +12,14 @@ class HistoryResource(newsroom.Resource):
     resource_methods = ['GET']
 
     schema = {
-        '_id': {type: 'string', 'unique': True},
-        'action': {type: 'string'},
+        '_id': {'type': 'string', 'unique': True},
+        'action': {'type': 'string'},
         'created': {'type': 'datetime'},
         'user': newsroom.Resource.rel('users'),
         'company': newsroom.Resource.rel('companies'),
         'item': newsroom.Resource.rel('items'),
         'version': {'type': 'string'},
+        'section': {'type': 'string'},
     }
 
     mongo_indexes = {
@@ -28,7 +29,7 @@ class HistoryResource(newsroom.Resource):
 
 
 class HistoryService(newsroom.Service):
-    def create(self, docs, action, user, **kwargs):
+    def create(self, docs, action, user, section='wire', **kwargs):
         now = utcnow()
 
         def transform(item):
@@ -40,6 +41,7 @@ class HistoryService(newsroom.Service):
                 'company': user.get('company'),
                 'item': item['_id'],
                 'version': item.get('version', item.get('_current_version')),
+                'section': section,
             }
 
         for doc in docs:
@@ -49,12 +51,14 @@ class HistoryService(newsroom.Service):
                 continue
 
 
-def get_history_users(item_ids, active_user_ids, active_company_ids):
+def get_history_users(item_ids, active_user_ids, active_company_ids, section, action):
 
     lookup = {
         'item': {'$in': item_ids},
         'user': {'$in': active_user_ids},
-        'company': {'$in': active_company_ids}
+        'company': {'$in': active_company_ids},
+        'section': section,
+        'action': action
     }
 
     histories = query_resource('history', lookup=lookup)

--- a/newsroom/notifications/notifications.py
+++ b/newsroom/notifications/notifications.py
@@ -17,7 +17,7 @@ class NotificationsResource(newsroom.Resource):
     item_methods = ['GET', 'PATCH', 'DELETE']
 
     schema = {
-        '_id': {type: 'string', 'unique': True},
+        '_id': {'type': 'string', 'unique': True},
         'item': newsroom.Resource.rel('items'),
         'user': newsroom.Resource.rel('users'),
         'created': {'type': 'dict', 'nullable': True},

--- a/newsroom/wire/search.py
+++ b/newsroom/wire/search.py
@@ -444,7 +444,22 @@ class WireSearchService(newsroom.Service):
         """
         bookmark_users = []
 
-        search_results = self.get_items(item_ids)
+        query = {
+            'bool': {
+                'must_not': [
+                    {'term': {'type': 'composite'}},
+                ],
+                'must': [
+                    {'terms': {'_id': item_ids}}
+                ],
+            }
+        }
+        get_resource_service('section_filters').apply_section_filter(query, self.section)
+
+        source = {'query': query}
+        internal_req = ParsedRequest()
+        internal_req.args = {'source': json.dumps(source)}
+        search_results = super().get(internal_req, None)
 
         if not search_results:
             return bookmark_users

--- a/newsroom/wire/views.py
+++ b/newsroom/wire/views.py
@@ -170,7 +170,13 @@ def download(_ids):
         _file.seek(0)
 
     update_action_list(_ids.split(','), 'downloads', force_insert=True)
-    app.data.insert('history', items, action='download', user=user)
+    app.data.insert(
+        'history',
+        items,
+        action='download',
+        user=user,
+        section=request.args.get('type', 'wire')
+    )
     return flask.send_file(_file, mimetype=mimetype, attachment_filename=attachment_filename, as_attachment=True)
 
 

--- a/tests/aap/test_am_news.py
+++ b/tests/aap/test_am_news.py
@@ -1,10 +1,16 @@
 from tests.fixtures import items, init_items, init_auth, init_company, PUBLIC_USER_ID  # noqa
 from tests.utils import json, get_json
+from tests.test_download import wire_formats, download_zip_file, items_ids
+from tests.test_push import get_signature_headers
+
+from superdesk import get_resource_service
+from superdesk.utc import utcnow
 
 from flask import g
 from bson import ObjectId
 from datetime import datetime, timedelta
 from urllib import parse
+import zipfile
 
 
 def test_blueprint_registration(client):
@@ -82,14 +88,14 @@ def test_bookmarks_by_section(client, app):
 
     assert 0 == get_bookmarks_count(client, PUBLIC_USER_ID)
 
-    resp = client.post('/wire_bookmark', data=json.dumps({
+    resp = client.post('/am_news_bookmark', data=json.dumps({
         'items': [items[0]['_id']],
     }), content_type='application/json')
     assert resp.status_code == 200
 
     assert 1 == get_bookmarks_count(client, PUBLIC_USER_ID)
 
-    client.delete('/wire_bookmark', data=json.dumps({
+    client.delete('/am_news_bookmark', data=json.dumps({
         'items': [items[0]['_id']],
     }), content_type='application/json')
     assert resp.status_code == 200
@@ -387,3 +393,145 @@ def test_share_items(client, app):
 
     user_id = app.data.find_all('users')[0]['_id']
     assert str(user_id) in data['shares']
+
+
+def test_download(client, app):
+    for _format in wire_formats:
+        _file = download_zip_file(client, _format['format'], 'am_news')
+        with zipfile.ZipFile(_file) as zf:
+            assert _format['filename'] in zf.namelist()
+            content = zf.open(_format['filename']).read()
+            _format['test_content'](content)
+    history = app.data.find('history', None, None)
+    assert len(items_ids) == history.count()
+    assert 'download' == history[0]['action']
+    assert history[0].get('user')
+    assert history[0].get('created') + timedelta(seconds=2) >= utcnow()
+    assert history[0].get('item') in items_ids
+    assert history[0].get('version')
+    assert history[0].get('company') is None
+    assert history[0].get('section') == 'am_news'
+
+
+def test_notify_user_matches_for_new_item_in_history(client, app, mocker):
+    company_ids = app.data.insert('companies', [{
+        'name': 'Press co.',
+        'is_enabled': True,
+    }])
+
+    user = {
+        'email': 'foo@bar.com',
+        'first_name': 'Foo',
+        'is_enabled': True,
+        'receive_email': True,
+        'company': company_ids[0],
+    }
+
+    user_ids = app.data.insert('users', [user])
+    user['_id'] = user_ids[0]
+
+    app.data.insert('history', docs=[{
+        'version': '1',
+        '_id': 'bar',
+    }], action='download', user=user, section='am_news')
+
+    with app.mail.record_messages() as outbox:
+        key = b'something random'
+        app.config['PUSH_KEY'] = key
+        data = json.dumps({'guid': 'bar', 'type': 'text', 'headline': 'this is a test'})
+        push_mock = mocker.patch('newsroom.push.push_notification')
+        headers = get_signature_headers(data, key)
+        resp = client.post('/push', data=data, content_type='application/json', headers=headers)
+        assert 200 == resp.status_code
+        assert push_mock.call_args[1]['item']['_id'] == 'bar'
+        assert len(push_mock.call_args[1]['users']) == 1
+
+        notification = get_resource_service('notifications').find_one(req=None, user=user_ids[0])
+        assert notification['item'] == 'bar'
+
+    assert len(outbox) == 1
+    assert 'http://localhost:5050/am_news?item=bar' in outbox[0].body
+
+
+def test_notify_user_matches_for_new_item_in_bookmarks(client, app, mocker):
+    app.data.insert('section_filters', [{
+        '_id': 'f-1',
+        'name': 'product test 1',
+        'query': 'NOT service.code:a',
+        'is_enabled': True,
+        'filter_type': 'wire'
+    }, {
+        '_id': 'f-2',
+        'name': 'product test 2',
+        'query': 'service.code:a',
+        'is_enabled': True,
+        'filter_type': 'am_news'
+    }, {
+        '_id': 'f-3',
+        'name': 'product test 3',
+        'query': 'NOT service.code:a',
+        'is_enabled': True,
+        'filter_type': 'aapX'
+    }])
+
+    app.data.insert('companies', [{
+        '_id': '2',
+        'name': 'Press co.',
+        'is_enabled': True,
+    }])
+
+    user = {
+        'email': 'foo@bar.com',
+        'first_name': 'Foo',
+        'is_enabled': True,
+        'receive_email': True,
+        'company': '2',
+    }
+
+    user_ids = app.data.insert('users', [user])
+    user['_id'] = user_ids[0]
+
+    app.data.insert('products', [{
+        "_id": 1,
+        "name": "Service A",
+        "query": "service.code: a",
+        "is_enabled": True,
+        "description": "Service A",
+        "companies": ['2'],
+        "sd_product_id": None,
+        "product_type": "am_news",
+    }])
+
+    app.data.insert('items', [{
+        '_id': 'bar',
+        'headline': 'testing',
+        'service': [{'code': 'a', 'name': 'Service A'}],
+        'products': [{'code': 1, 'name': 'product-1'}],
+    }])
+
+    with client.session_transaction() as session:
+        session['user'] = user['_id']
+        session['user_type'] = 'public'
+        session['name'] = 'public'
+
+    resp = client.post('/am_news_bookmark', data=json.dumps({
+        'items': ['bar'],
+    }), content_type='application/json')
+    assert resp.status_code == 200
+
+    with app.mail.record_messages() as outbox:
+        key = b'something random'
+        app.config['PUSH_KEY'] = key
+        data = json.dumps({'guid': 'bar', 'type': 'text', 'headline': 'this is a test'})
+        push_mock = mocker.patch('newsroom.push.push_notification')
+        headers = get_signature_headers(data, key)
+        resp = client.post('/push', data=data, content_type='application/json', headers=headers)
+        assert 200 == resp.status_code
+        assert push_mock.call_args_list[0][0][0] == 'new_item'
+        assert push_mock.call_args_list[1][0][0] == 'history_matches'
+        assert push_mock.call_args[1]['item']['_id'] == 'bar'
+        notification = get_resource_service('notifications').find_one(req=None, user=user_ids[0])
+        assert notification['item'] == 'bar'
+
+    assert len(outbox) == 1
+    assert 'http://localhost:5050/am_news?item=bar' in outbox[0].body

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -13,8 +13,8 @@ items_ids = [item['_id'] for item in items[:2]]
 item = items[:2][0]
 
 
-def download_zip_file(client, _format):
-    resp = client.get('/download/%s?format=%s&type=wire' % (','.join(items_ids), _format))
+def download_zip_file(client, _format, section):
+    resp = client.get('/download/%s?format=%s&type=%s' % (','.join(items_ids), _format, section))
     assert resp.status_code == 200
     assert resp.mimetype == 'application/zip'
     assert resp.headers.get('Content-Disposition') == 'attachment; filename={}-newsroom.zip'.format(
@@ -121,7 +121,7 @@ def test_download_single(client, app):
 
 def test_wire_download(client, app):
     for _format in wire_formats:
-        _file = download_zip_file(client, _format['format'])
+        _file = download_zip_file(client, _format['format'], 'wire')
         with zipfile.ZipFile(_file) as zf:
             assert _format['filename'] in zf.namelist()
             content = zf.open(_format['filename']).read()
@@ -134,6 +134,7 @@ def test_wire_download(client, app):
     assert history[0].get('item') in items_ids
     assert history[0].get('version')
     assert history[0].get('company') is None
+    assert history[0].get('section') == 'wire'
 
 
 def test_agenda_download(client, app):

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -260,20 +260,24 @@ def test_notify_user_matches_for_new_item_in_history(client, app, mocker):
     app.data.insert('history', docs=[{
         'version': '1',
         '_id': 'bar',
-    }], action='download', user=user)
+    }], action='download', user=user, section='wire')
 
-    key = b'something random'
-    app.config['PUSH_KEY'] = key
-    data = json.dumps({'guid': 'bar', 'type': 'text', 'headline': 'this is a test'})
-    push_mock = mocker.patch('newsroom.push.push_notification')
-    headers = get_signature_headers(data, key)
-    resp = client.post('/push', data=data, content_type='application/json', headers=headers)
-    assert 200 == resp.status_code
-    assert push_mock.call_args[1]['item']['_id'] == 'bar'
-    assert len(push_mock.call_args[1]['users']) == 1
+    with app.mail.record_messages() as outbox:
+        key = b'something random'
+        app.config['PUSH_KEY'] = key
+        data = json.dumps({'guid': 'bar', 'type': 'text', 'headline': 'this is a test'})
+        push_mock = mocker.patch('newsroom.push.push_notification')
+        headers = get_signature_headers(data, key)
+        resp = client.post('/push', data=data, content_type='application/json', headers=headers)
+        assert 200 == resp.status_code
+        assert push_mock.call_args[1]['item']['_id'] == 'bar'
+        assert len(push_mock.call_args[1]['users']) == 1
 
-    notification = get_resource_service('notifications').find_one(req=None, user=user_ids[0])
-    assert notification['item'] == 'bar'
+        notification = get_resource_service('notifications').find_one(req=None, user=user_ids[0])
+        assert notification['item'] == 'bar'
+
+    assert len(outbox) == 1
+    assert 'http://localhost:5050/wire?item=bar' in outbox[0].body
 
 
 def test_notify_user_matches_for_killed_item_in_history(client, app, mocker):
@@ -322,7 +326,8 @@ def test_notify_user_matches_for_killed_item_in_history(client, app, mocker):
 
 
 def test_notify_user_matches_for_new_item_in_bookmarks(client, app, mocker):
-    company_ids = app.data.insert('companies', [{
+    app.data.insert('companies', [{
+        '_id': '2',
         'name': 'Press co.',
         'is_enabled': True,
     }])
@@ -332,24 +337,56 @@ def test_notify_user_matches_for_new_item_in_bookmarks(client, app, mocker):
         'first_name': 'Foo',
         'is_enabled': True,
         'receive_email': True,
-        'company': company_ids[0],
+        'company': '2',
     }
 
     user_ids = app.data.insert('users', [user])
     user['_id'] = user_ids[0]
 
-    app.data.insert('items', [{'_id': 'bar', 'headline': 'testing', 'bookmarks': [user_ids[0]]}])
+    app.data.insert('products', [{
+        "_id": 1,
+        "name": "Service A",
+        "query": "service.code: a",
+        "is_enabled": True,
+        "description": "Service A",
+        "companies": ['2'],
+        "sd_product_id": None,
+        "product_type": "wire",
+    }])
 
-    key = b'something random'
-    app.config['PUSH_KEY'] = key
-    data = json.dumps({'guid': 'bar', 'type': 'text', 'headline': 'this is a test'})
-    push_mock = mocker.patch('newsroom.push.push_notification')
-    headers = get_signature_headers(data, key)
-    resp = client.post('/push', data=data, content_type='application/json', headers=headers)
-    assert 200 == resp.status_code
-    assert push_mock.call_args_list[0][0][0] == 'new_item'
-    assert push_mock.call_args_list[1][0][0] == 'history_matches'
-    assert push_mock.call_args[1]['item']['_id']
+    app.data.insert('items', [{
+        '_id': 'bar',
+        'headline': 'testing',
+        'service': [{'code': 'a', 'name': 'Service A'}],
+        'products': [{'code': 1, 'name': 'product-1'}],
+    }])
+
+    with client.session_transaction() as session:
+        session['user'] = user['_id']
+        session['user_type'] = 'public'
+        session['name'] = 'public'
+
+    resp = client.post('/wire_bookmark', data=json.dumps({
+        'items': ['bar'],
+    }), content_type='application/json')
+    assert resp.status_code == 200
+
+    with app.mail.record_messages() as outbox:
+        key = b'something random'
+        app.config['PUSH_KEY'] = key
+        data = json.dumps({'guid': 'bar', 'type': 'text', 'headline': 'this is a test'})
+        push_mock = mocker.patch('newsroom.push.push_notification')
+        headers = get_signature_headers(data, key)
+        resp = client.post('/push', data=data, content_type='application/json', headers=headers)
+        assert 200 == resp.status_code
+        assert push_mock.call_args_list[0][0][0] == 'new_item'
+        assert push_mock.call_args_list[1][0][0] == 'history_matches'
+        assert push_mock.call_args[1]['item']['_id']
+        notification = get_resource_service('notifications').find_one(req=None, user=user_ids[0])
+        assert notification['item'] == 'bar'
+
+    assert len(outbox) == 1
+    assert 'http://localhost:5050/wire?item=bar' in outbox[0].body
 
 
 def test_do_not_notify_inactive_user(client, app, mocker):
@@ -453,6 +490,7 @@ def test_send_notification_emails(client, app):
         resp = client.post('/push', data=data, content_type='application/json', headers=headers)
         assert 200 == resp.status_code
     assert len(outbox) == 1
+    assert 'http://localhost:5050/wire?item=foo' in outbox[0].body
 
 
 def test_matching_topics(client, app):


### PR DESCRIPTION
* Store section with history entries
* wire/search: get_matching_bookmarks should apply section/product filters