### PR TITLE
Updating superdesk-core version for newsroom package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_requires = [
     'flask_pymongo>=0.5.2,<1.0',
     'honcho>=1.0.1',
     'gunicorn>=19.7.1',
-    'superdesk-core>=1.29,<=1.30',
+    'superdesk-core>=1.31.1,<=1.32',
     'icalendar>=4.0.3,<4.1',
 ]
 


### PR DESCRIPTION
This is to address the install error we get when we use newsroom as a dependency in another repository:

`ERROR: No matching distribution found for hachoir3<=3.0a2,>=3.0a1 (from superdesk-core<=1.30,>=1.29->Newsroom->-r requirements.txt (line 1))`