### PR TITLE
fix(build) Pin the version of WTForms and fix failing tests

### DIFF
--- a/features/news_api_auth.feature
+++ b/features/news_api_auth.feature
@@ -128,6 +128,7 @@ Feature: News API Authorization
      """
 
   @rate_limit
+  @notification
   Scenario: RATE_LIMIT_REQUESTS config is used for request validation
      Given "items"
         """

--- a/features/news_api_search.feature
+++ b/features/news_api_search.feature
@@ -455,6 +455,7 @@ Feature: News API News Search
      """
 
   @rate_limit
+  @notification  
   Scenario: X-RateLimit-Remaining header is set in response
      Given "items"
         """
@@ -479,6 +480,7 @@ Feature: News API News Search
       """
 
   @rate_limit
+  @notification
   Scenario: X-RateLimit-Reset header is set in response
      Given "items"
         """

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ install_requires = [
     'Babel>=2.5.3,<3.0',
     'eve==0.7.8',
     'eve-elastic==2.5.0',
+    'WTForms==2.2.1',
     'flask>=0.12,<1.0',
     'flask-babel>=0.11.2,<0.12',
     'flask-webpack>=0.1.0,<0.2',


### PR DESCRIPTION
A new WTForms version now has a dependency on email_validator, adding that caused a number of tests to fail, so It's been pinned it back to the old version.

Also superdesk-core 1.33 broke a couple of tests.