### PR TITLE
fix(news-api) remove unwanted fields

### DIFF
--- a/newsroom/news_api/news/feed/service.py
+++ b/newsroom/news_api/news/feed/service.py
@@ -84,6 +84,9 @@ class NewsAPIFeedService(NewsAPINewsService):
                 'href': 'news/item/{}'.format(doc_id),
                 'title': 'News Item'
             }
+            item.pop('_updated', None)
+            item.pop('_created', None)
+            item.pop('_etag', None)
 
     def _hateoas_set_next_page_links(self, doc):
         args = request.args.to_dict()

--- a/newsroom/news_api/news/search/service.py
+++ b/newsroom/news_api/news/search/service.py
@@ -22,3 +22,6 @@ class NewsAPISearchService(NewsAPINewsService):
                 'href': 'news/item/{}'.format(doc_id),
                 'title': 'News Item'
             }
+            item.pop('_updated', None)
+            item.pop('_created', None)
+            item.pop('_etag', None)


### PR DESCRIPTION
_updated and _created always get populated by eve with the default date 1-jan-1970. 