### PR TITLE
Set RESET_PASSWORD_TOKEN_TIME_TO_LIVE to 7 days

### DIFF
--- a/newsroom/default_settings.py
+++ b/newsroom/default_settings.py
@@ -154,7 +154,7 @@ NEW_ACCOUNT_ACTIVE_DAYS = 14
 WTF_CSRF_ENABLED = True
 
 #: The number of days a token is valid
-RESET_PASSWORD_TOKEN_TIME_TO_LIVE = 1
+RESET_PASSWORD_TOKEN_TIME_TO_LIVE = 7
 #: The number of days a validation token is valid
 VALIDATE_ACCOUNT_TOKEN_TIME_TO_LIVE = 1
 #: The number login attempts allowed before account is locked


### PR DESCRIPTION
SDESK-5602 Change expiry time for password change in auto-generated emails from 1 to 7 days
⚠️ since "core" is not decoupled from the custom instance yet, but the feature is required by the client, I sent 2 PRs, one to develop branch another to stt