### PR TITLE
fix logging download endpoints route getting confused by AWS storage folders

### DIFF
--- a/assets/ui/components/ArticleBodyHtml.jsx
+++ b/assets/ui/components/ArticleBodyHtml.jsx
@@ -200,7 +200,7 @@ class ArticleBodyHtml extends React.PureComponent {
                     vTag.setAttribute('data-plyr-config', '{"controls": ["play-large", "play",' +
                         '"progress", "volume", "mute", "rewind", "fast-forward", "current-time",' +
                         '"captions", "restart", "duration", "download"], "urls": {"download": ' +
-                        '"' + vTag.getAttribute('src') + '/' + item._id + '"' +
+                        '"' + vTag.getAttribute('src') + '?item_id=' + item._id + '"' +
                         '}}');
                 }
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -31,7 +31,8 @@ def before_scenario(context, scenario):
         'NEWS_API_ENABLED': True,
         'NEWS_API_IMAGE_PERMISSIONS_ENABLED': True,
         'NEWS_API_TIME_LIMIT_DAYS': 100,
-        'NEWS_API_ALLOWED_RENDITIONS': 'original,16-9'
+        'NEWS_API_ALLOWED_RENDITIONS': 'original,16-9',
+        'EMBED_PRODUCT_FILTERING': True,
     }
 
     if 'rate_limit' in scenario.tags:

--- a/features/news_api_atom.feature
+++ b/features/news_api_atom.feature
@@ -87,7 +87,7 @@ Feature: News API News Search
         ],
         "query": "",
         "sd_product_id": "1",
-        "product_type": "wire"
+        "product_type": "news_api"
         }]
         """
     Given "items"

--- a/newsroom/news_api/formatters/service.py
+++ b/newsroom/news_api/formatters/service.py
@@ -44,7 +44,7 @@ class APIFormattersService(Service):
         if utcnow() - timedelta(days=int(get_setting('news_api_time_limit_days'))) > item.get('versioncreated',
                                                                                               utcnow()):
             abort(404)
-        remove_unpermissioned_embeds(item, g.user)
+        remove_unpermissioned_embeds(item, g.user, 'news_api')
         set_embed_links(item)
         ret = formatter.format_item(item)
         return {'formatted_item': ret, 'mimetype': formatter.MIMETYPE, 'version': item.get('version')}

--- a/newsroom/news_api/news/assets/assets.py
+++ b/newsroom/news_api/news/assets/assets.py
@@ -15,19 +15,6 @@ def init_app(app):
     superdesk.blueprint(blueprint, app)
 
 
-@blueprint.route('/assets/<path:asset_id>/<item_id>', methods=['GET'])
-def download(asset_id, item_id):
-    """
-    Called on download of a media item, keeps a record of the download
-    :param media_id:
-    :param item_id:
-    :return:
-    """
-    response = get_item(asset_id)
-    superdesk.get_resource_service('history').log_api_media_download(item_id, asset_id)
-    return response
-
-
 @blueprint.route('/assets/<path:asset_id>', methods=['GET'])
 def get_item(asset_id):
     auth = app.auth
@@ -41,6 +28,10 @@ def get_item(asset_id):
                     abort(401, gettext('Invalid token'))
         else:
             return abort(401, gettext('Invalid token'))
+
+    item_id = request.args.get('item_id')
+    if item_id:
+        superdesk.get_resource_service('history').log_api_media_download(item_id, asset_id)
     try:
         media_file = flask.current_app.media.get(asset_id, ASSETS_RESOURCE)
     except bson.errors.InvalidId:

--- a/newsroom/news_api/news/atom/atom.py
+++ b/newsroom/news_api/news/atom/atom.py
@@ -71,7 +71,7 @@ def get_atom(token=None):
             if ((complete_item.get('associations') or {}).get('featuremedia') or {}).get('renditions'):
                 if not check_association_permission(complete_item):
                     continue
-            remove_unpermissioned_embeds(complete_item, g.user)
+            remove_unpermissioned_embeds(complete_item, g.user, 'news_api')
 
             entry = SubElement(feed, 'entry')
 

--- a/newsroom/news_api/news/rss/rss.py
+++ b/newsroom/news_api/news/rss/rss.py
@@ -72,7 +72,7 @@ def get_rss(token=None):
             if ((complete_item.get('associations') or {}).get('featuremedia') or {}).get('renditions'):
                 if not check_association_permission(complete_item):
                     continue
-            remove_unpermissioned_embeds(complete_item, g.user)
+            remove_unpermissioned_embeds(complete_item, g.user, 'news_api')
 
             entry = SubElement(channel, 'item')
 

--- a/newsroom/news_api/news/search_service.py
+++ b/newsroom/news_api/news/search_service.py
@@ -71,7 +71,7 @@ class NewsAPINewsService(BaseSearchService):
                 doc.pop(field, None)
 
             if 'associations' in orig_request_params.get('include_fields', ''):
-                remove_unpermissioned_embeds(doc, g.user)
+                remove_unpermissioned_embeds(doc, g.user, 'news_api')
                 set_embed_links(doc)
                 if not check_association_permission(doc):
                     doc.pop('associations', None)

--- a/newsroom/news_api/utils.py
+++ b/newsroom/news_api/utils.py
@@ -92,7 +92,7 @@ def set_embed_links(item):
     """
 
     def update_url(item, elem, group):
-        elem.attrib["src"] = elem.attrib["src"] + "/" + item.get("_id")
+        elem.attrib["src"] = elem.attrib["src"] + "?item_id=" + item.get("_id")
         return True
 
     if not app.config.get("EMBED_PRODUCT_FILTERING"):
@@ -108,7 +108,7 @@ def set_embed_links(item):
                 if ass.get('renditions', {}).get(rendition, {}).get("href"):
                     ass.get('renditions', {}).get(rendition, {})["href"] = ass.get('renditions', {}).get(rendition,
                                                                                                          {}).get(
-                        "href") + '/' + item.get("_id")
+                        "href") + '?item_id=' + item.get("_id")
 
 
 def update_embed_urls(item, token):
@@ -127,9 +127,12 @@ def update_embed_urls(item, token):
         src = item.get("associations", {}).get(embed_id, {}).get("renditions", {}).get(
             rendition)
         if src is not None and elem is not None:
-            token_param = {'token': token} if token else {}
-            elem.attrib["src"] = url_for('assets.download', asset_id=src.get('media'), item_id=item.get("_id"),
-                                         _external=True, **token_param)
+            params = {"item_id": item.get("_id")}
+            if token:
+                params["token"] = token
+            elem.attrib["src"] = url_for('assets.get_item', asset_id=src.get('media'),
+                                         _external=True, **params)
         return True
 
-    update_embeds_in_body(item, update_embed, update_embed, update_embed)
+    if app.config.get("EMBED_PRODUCT_FILTERING"):
+        update_embeds_in_body(item, update_embed, update_embed, update_embed)

--- a/newsroom/upload.py
+++ b/newsroom/upload.py
@@ -24,19 +24,6 @@ def get_file(key):
         return url_for('upload.get_upload', media_id=filename)
 
 
-@blueprint.route('/assets/<path:media_id>/<item_id>', methods=['GET'])
-@login_required
-def download(media_id, item_id):
-    """
-    Called on download of a media item, keeps a record of the download
-    :param media_id:
-    :param item_id:
-    :return:
-    """
-    get_resource_service('history').log_media_download(item_id, media_id)
-    return get_upload(media_id)
-
-
 @blueprint.route('/assets/<path:media_id>', methods=['GET'])
 @login_required
 def get_upload(media_id):
@@ -65,6 +52,10 @@ def get_upload(media_id):
         response.headers['Content-Disposition'] = 'attachment; filename="%s"' % flask.request.args['filename']
     else:
         response.headers['Content-Disposition'] = 'inline'
+
+    item_id = request.args.get('item_id')
+    if item_id:
+        get_resource_service('history').log_media_download(item_id, media_id)
 
     return response
 


### PR DESCRIPTION
The '/' in the media path confused the route so wouldn't match the endpoint